### PR TITLE
v0.2.0: fetch + normalize + chat adapter + PyPI token publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 # Publish to PyPI when a version tag is pushed (e.g. v0.1.0).
-# Register this GitHub repo as a trusted publisher on PyPI (project settings).
+# Uses a PyPI API token stored as the GitHub Actions secret ``PYPI_API_TOKEN``.
+# To rotate: regenerate the token on pypi.org and replace the secret value.
 
 name: Publish
 
@@ -12,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -30,3 +30,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-20
+
+### Added
+
+- `convmerge fetch`: YAML-manifest driven downloader for HuggingFace and GitHub
+  sources, with single-URL / `hf://` shortcut mode. See `docs/fetch.md`.
+  - GitHub: raw URL download, Trees API recursive fetch with extension filter,
+    `git clone` with optional `git lfs pull`.
+  - HuggingFace: thin wrapper over `datasets.load_dataset(...).to_json(...)`.
+  - Token resolution order: CLI flag → file → env var. URLs are redacted in logs.
+- `convmerge normalize`: parquet / JSON array / single-line concatenated JSON
+  → clean newline-delimited JSONL, batch over directories.
+- `convmerge dedupe`: streaming MD5/SHA256-based deduplication, optional key
+  projection.
+- `convmerge turns`: single-turn vs multi-turn distribution report and
+  deterministic file split.
+- `convmerge.adapters.chat` / `auto`: auto-detecting adapter for
+  `messages` / `conversation` / `conversations` / `text` / pairwise preference
+  rows with overridable role map.
+- Optional extras: `[fetch]` (pyyaml), `[fetch-hf]` (datasets),
+  `[fetch-all]`, `[parquet]` (pyarrow).
+
+### Changed
+
+- PyPI publish workflow now authenticates with the `PYPI_API_TOKEN` GitHub
+  Actions secret instead of OIDC trusted publishing.
+
+[0.2.0]: https://pypi.org/project/convmerge/0.2.0/
+
 ## [0.1.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,48 +1,115 @@
 # convmerge
 
-Merge heterogeneous chat-oriented JSONL sources into a **single LLM training format** (JSONL).
+Fetch, normalize, and convert heterogeneous chat / instruct datasets into a
+**single LLM training format** (JSONL).
 
 **Repository:** [github.com/snowmuffin/convmerge](https://github.com/snowmuffin/convmerge)  
-**Status:** early development; APIs and CLI may change before 1.0.
+**Status:** pre-1.0; APIs and CLI may change between minor versions.
 
 ## Install
 
 ```bash
-pip install convmerge
+pip install convmerge                    # core: convert, normalize, dedupe, turns
+pip install "convmerge[fetch]"           # + YAML manifest fetcher (GitHub)
+pip install "convmerge[fetch-hf]"        # + HuggingFace entries (adds ``datasets``)
+pip install "convmerge[fetch-all]"       # all fetch-related extras
+pip install "convmerge[parquet]"         # + parquet streaming input
 ```
 
-(After the first release on PyPI. Until then, from a clone:)
+Or from a clone:
 
 ```bash
 git clone https://github.com/snowmuffin/convmerge.git
 cd convmerge
 python -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
+pip install -e ".[dev,fetch-all,parquet]"
 ```
 
-## Usage
+## The four use cases
+
+### 1. `fetch` — pull raw data from HF + GitHub via a YAML manifest
+
+```yaml
+# manifest.yaml
+version: 1
+defaults: { output_root: ./raw, resume: true }
+auth:     { hf_token_env: HF_TOKEN, github_token_env: GITHUB_TOKEN }
+datasets:
+  - { name: alpaca-ko, hf: MarkrAI/KoCommercial-Dataset, split: train }
+  - { name: orca-raw,
+      url: https://raw.githubusercontent.com/org/repo/main/data/train.jsonl }
+  - { name: repo-tree,
+      url: https://github.com/org/example-repo, ext: [".jsonl"] }
+  - { name: big-lfs,
+      url: https://github.com/org/big-lfs-repo, mode: clone, lfs: true }
+```
 
 ```bash
-convmerge convert \
-  --input samples/alpaca.jsonl \
-  --output out/messages.jsonl \
-  --from alpaca \
-  --format messages
+convmerge fetch manifest.yaml -o ./raw
+# or one-shot shortcuts:
+convmerge fetch hf://org/dataset -o ./raw --split train
+convmerge fetch https://github.com/org/repo -o ./raw --ext .jsonl
 ```
 
-- **`--from`**: source adapter (`alpaca`, `sharegpt`, …).
-- **`--format`**: output shape (`messages`, `alpaca`, …).
+Tokens resolve in order CLI flag → file → env var, and are redacted from logs.
+See [docs/fetch.md](docs/fetch.md) for the full schema.
 
-See [docs/format.md](docs/format.md) for schemas and how to add adapters.
+### 2. `normalize` — reshape parquet / messy JSON into clean JSONL
+
+```bash
+convmerge normalize -i ./raw -o ./jsonl
+```
+
+Handles parquet (streamed via `pyarrow`), top-level JSON arrays, concatenated
+single-line JSON (`{...}{...}{...}`), and already-valid JSONL. A directory
+input is walked recursively and mirrored under the output directory.
+
+### 3. `convert` — adapter + emitter pipeline
+
+```bash
+convmerge convert -i ./jsonl/alpaca.jsonl -o ./train/alpaca.messages.jsonl \
+  --from alpaca --format messages
+
+convmerge convert -i ./jsonl/mixed.jsonl -o ./train/mixed.messages.jsonl \
+  --from auto --format messages         # auto-detecting chat adapter
+```
+
+Adapters: `alpaca`, `sharegpt`, `chat` (alias `auto`).  
+Emitters: `messages`, `alpaca`.
+
+### 4. `dedupe` / `turns` — final cleanup + train/eval split hook
+
+```bash
+convmerge dedupe -i ./train/mixed.messages.jsonl -o ./train/mixed.dedup.jsonl
+convmerge turns  -i ./train/mixed.dedup.jsonl \
+  --single-out ./train/single.jsonl \
+  --multi-out  ./train/multi.jsonl
+```
+
+See [docs/format.md](docs/format.md) for adapter / emitter schemas and
+[docs/fetch.md](docs/fetch.md) for manifest details.
 
 ## Development
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). CI runs on every push to `main` (Ruff + pytest on Python 3.10–3.12).
+See [CONTRIBUTING.md](CONTRIBUTING.md). CI runs Ruff + pytest on Python
+3.10 – 3.12.
+
+```bash
+ruff check src tests
+pytest -q
+```
 
 ## PyPI release (maintainers)
 
-1. On [pypi.org](https://pypi.org), create the `convmerge` project (or claim the name) and add **trusted publishing** for this GitHub repo (`snowmuffin/convmerge`, workflow `publish.yml`, environment optional per your PyPI settings).
-2. Tag and push: `git tag v0.1.0 && git push origin v0.1.0` — this runs [`.github/workflows/publish.yml`](.github/workflows/publish.yml).
+Releases run from [`.github/workflows/publish.yml`](.github/workflows/publish.yml)
+on pushing a `v*` tag. Publishing authenticates via the **`PYPI_API_TOKEN`**
+GitHub Actions secret (a PyPI API token scoped to the `convmerge` project).
+
+1. Create an API token on [pypi.org](https://pypi.org/manage/account/token/)
+   scoped to `convmerge`.
+2. In the GitHub repo, *Settings → Secrets and variables → Actions → New
+   repository secret*, add `PYPI_API_TOKEN` with the token value.
+3. Tag and push: `git tag v0.2.0 && git push origin v0.2.0`.
 
 ## Changelog
 

--- a/docs/fetch.md
+++ b/docs/fetch.md
@@ -1,0 +1,146 @@
+# Fetching datasets with a YAML manifest
+
+The `convmerge fetch` subcommand reads a YAML manifest listing HuggingFace
+datasets and/or GitHub URLs and downloads each one into a per-source directory
+under a shared output root. It is intentionally a thin layer: HuggingFace
+entries delegate to `datasets.load_dataset`, and GitHub entries use either the
+stdlib HTTP client, the Trees API, or `git clone` depending on the entry.
+
+```bash
+pip install "convmerge[fetch-all]"   # YAML + HuggingFace datasets
+convmerge fetch manifest.yaml -o ./raw
+```
+
+## Install extras
+
+| Extra         | Pulls in              | Required for                   |
+|---------------|-----------------------|--------------------------------|
+| `fetch`       | `pyyaml`              | manifest parsing, GitHub only  |
+| `fetch-hf`    | `pyyaml`, `datasets`  | HuggingFace entries            |
+| `fetch-all`   | above combined        | everything                      |
+
+Raw GitHub URLs and the Trees API use Python's `urllib.request` — no extra
+dependency for pure-GitHub manifests beyond PyYAML.
+
+## Manifest schema (version 1)
+
+```yaml
+version: 1
+
+defaults:
+  output_root: ./raw            # default destination directory
+  on_error: continue            # "continue" (default) or "fail"
+  resume: true                  # skip entries whose output already exists
+
+auth:
+  hf_token_env: HF_TOKEN        # env var to read the HF token from
+  hf_token_file: ~/.cache/hf.token
+  github_token_env: GITHUB_TOKEN
+  github_token_file: ~/.cache/gh.token
+
+datasets:
+  # HuggingFace
+  - name: alpaca-gpt4-ko
+    hf: MarkrAI/KoCommercial-Dataset
+    split: train                # optional; defaults to "train"
+    config: null                # optional dataset config/subset
+
+  # Single raw file (GitHub raw URL or any direct .json/.jsonl/.json.gz URL)
+  - name: orca-math
+    url: https://raw.githubusercontent.com/org/repo/main/data/train.jsonl
+
+  # Whole GitHub repo, filtered by extension, via the Trees API (no clone)
+  - name: example-repo
+    url: https://github.com/org/example-repo
+    ext: [".jsonl"]             # only files whose path ends with these
+
+  # Whole GitHub repo, cloned with git (useful for LFS-tracked large files)
+  - name: big-lfs-repo
+    url: https://github.com/org/big-lfs-repo
+    mode: clone
+    lfs: true                   # runs ``git lfs pull`` after clone
+```
+
+### Required fields per entry
+
+- `name` — unique label used to form the output subdirectory
+  (`sanitize_name` strips `<>:"/\|?*` and whitespace).
+- Exactly one of `hf` or `url`.
+- HuggingFace extras: `split`, `config`.
+- GitHub extras: `ext` (tuple of suffixes), `mode` (`tree` default, or `clone`),
+  `lfs` (bool, only meaningful when `mode: clone`).
+- `output` — optional explicit path that overrides `defaults.output_root / name`.
+
+## Authentication
+
+Tokens are resolved in this order, highest priority first:
+
+1. CLI flags: `--hf-token` / `--github-token`.
+2. File at `auth.hf_token_file` / `auth.github_token_file`.
+3. Environment variable at `auth.hf_token_env` / `auth.github_token_env`.
+
+Tokens are never printed. Any URL logged by the runner is passed through
+`convmerge.fetch.auth.redact_url` to strip `user:token@host` userinfo.
+
+For `mode: clone` entries the token is injected into the clone URL as
+`https://user:TOKEN@github.com/...` only when the host is `github.com` or
+`huggingface.co`; other hosts receive the URL untouched.
+
+## Resume behaviour
+
+With `defaults.resume: true` (the default) the runner inspects the expected
+output path for each entry:
+
+- HuggingFace / raw URL entries: a non-empty file counts as "done".
+- Trees / clone entries: a non-empty directory counts as "done".
+
+Pass `--no-resume` on the CLI to force a re-download.
+
+## Running
+
+```bash
+# Full manifest
+convmerge fetch manifest.yaml -o ./raw
+
+# Only a subset of entries by name
+convmerge fetch manifest.yaml --only alpaca-gpt4-ko orca-math
+
+# Fail-fast on any error
+convmerge fetch manifest.yaml --on-error fail
+
+# Tokens from CLI (override manifest / env)
+convmerge fetch manifest.yaml --hf-token "hf_xxx" --github-token "ghp_xxx"
+```
+
+### Single-URL shortcuts (no manifest)
+
+```bash
+# HuggingFace dataset -> ./raw/<sanitized>.jsonl
+convmerge fetch hf://org/dataset -o ./raw --split train
+
+# Raw GitHub file
+convmerge fetch https://raw.githubusercontent.com/o/r/m/a.jsonl -o ./raw
+
+# GitHub repo, Trees API, filtered by extension
+convmerge fetch https://github.com/org/repo -o ./raw --ext .jsonl .json
+
+# GitHub repo, full clone with LFS
+convmerge fetch https://github.com/org/big-repo -o ./raw --mode clone --lfs
+```
+
+## After fetching
+
+`convmerge fetch` only downloads. To actually prepare training data, chain the
+other subcommands:
+
+```bash
+convmerge fetch    manifest.yaml -o ./raw
+convmerge normalize -i ./raw -o ./jsonl         # parquet/json(l) -> clean jsonl
+convmerge convert  -i ./jsonl/some.jsonl \
+                   -o ./train/some.messages.jsonl \
+                   --from auto --format messages
+convmerge dedupe   -i ./train/some.messages.jsonl -o ./train/some.dedup.jsonl
+convmerge turns    -i ./train/some.dedup.jsonl \
+                   --single-out ./train/single.jsonl \
+                   --multi-out  ./train/multi.jsonl
+```

--- a/docs/format.md
+++ b/docs/format.md
@@ -40,6 +40,40 @@ Expects keys such as `instruction`, optional `input`, and `output` (or `response
 Expects `conversations`: list of `{"from": "human"|"gpt"|..., "value": "..."}`.
 Emits one example per consecutive user→assistant pair.
 
+### `chat` (alias: `auto`)
+
+Auto-detecting adapter for mixed / unknown chat schemas. Tries, in order:
+
+1. Pairwise preference rows (`conversation_a` / `conversation_b` with optional `winner`).
+   - Default `pairwise_mode="winner"` emits only the winning branch; ties/unknown are skipped.
+   - `pairwise_mode="both"` emits both branches; `"a"` / `"b"` always pick one side.
+2. Chat-list containers named `messages`, `conversation`, or `conversations`.
+   - Both `{role, content}` and ShareGPT-style `{from, value}` entries work.
+   - A default role map normalizes `human → user`, `gpt/bing/bot → assistant`.
+3. Plain `text` → emitted as a single assistant message.
+4. Fallback: alpaca-like keys (`instruction`/`question`/`prompt` + `output`/`response`/`answer`).
+
+You can override every part (`conversation_keys`, `role_keys`, `content_keys`,
+`role_map`, `instruction_keys`, `input_keys`, `output_keys`, `pairwise_mode`)
+when calling `iter_from_chat_line` programmatically.
+
+## Normalization utilities
+
+`convmerge.normalize` and the `convmerge normalize / dedupe / turns`
+subcommands handle the pre-adapter cleanup step:
+
+- `normalize_to_jsonl(src, dst)` — rewrites parquet, JSON arrays, concatenated
+  single-line JSON, or already-valid JSONL into clean newline-delimited JSONL.
+  Parquet requires the `parquet` extra.
+- `deduplicate_jsonl(src, dst, keys=None, algorithm="md5")` — streaming dedup
+  by an MD5/SHA256 hash of the whole record or a projected subset of keys.
+- `analyze_turn_distribution(path)` — reports single-turn vs multi-turn counts
+  for messages-style JSONL, plus a per-turn-count histogram.
+- `split_by_turns(src, single_out=..., multi_out=...)` — partitions a
+  messages-style JSONL into single-turn and multi-turn files.
+- `single_turn_to_multi_turn_record` / `multi_turn_to_single_turn_record` —
+  round-trip between `{instruction, input, output}` and `{messages: [...]}`.
+
 ## Non-goals (current)
 
 - **HTML / raw web pages**: full-site scraping and boilerplate removal are out of scope for core; a future optional extra may wrap libraries like `trafilatura`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "convmerge"
-version = "0.1.0"
-description = "Merge heterogeneous chat/text sources into a single LLM training format"
+version = "0.2.0"
+description = "Fetch, normalize, and convert heterogeneous chat/instruct datasets into a single LLM training format"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
@@ -24,6 +24,14 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
+# YAML manifest fetcher (GitHub raw / Trees API / git clone). Uses stdlib urllib for HTTP.
+fetch = ["pyyaml>=6.0"]
+# HuggingFace support for fetch (delegates to the ``datasets`` library).
+fetch-hf = ["pyyaml>=6.0", "datasets>=2.16"]
+# Alias: everything fetch-related.
+fetch-all = ["pyyaml>=6.0", "datasets>=2.16"]
+# Parquet streaming input for normalize.
+parquet = ["pyarrow>=14"]
 dev = ["pytest>=8.0", "ruff>=0.4"]
 
 [project.scripts]

--- a/src/convmerge/__init__.py
+++ b/src/convmerge/__init__.py
@@ -1,3 +1,3 @@
 """convmerge — merge heterogeneous sources into a single LLM training format."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/convmerge/adapters/__init__.py
+++ b/src/convmerge/adapters/__init__.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Iterator
 from typing import Any
 
 from convmerge.adapters.alpaca import iter_from_alpaca_line
+from convmerge.adapters.chat import iter_from_chat_line
 from convmerge.adapters.sharegpt import iter_from_sharegpt_line
 from convmerge.models import TrainingExample
 
@@ -14,6 +15,9 @@ AdapterFn = Callable[[dict[str, Any]], Iterator[TrainingExample]]
 ADAPTERS: dict[str, AdapterFn] = {
     "alpaca": iter_from_alpaca_line,
     "sharegpt": iter_from_sharegpt_line,
+    "chat": iter_from_chat_line,
+    # ``auto`` is an alias for ``chat`` since the chat adapter is already auto-detecting.
+    "auto": iter_from_chat_line,
 }
 
 

--- a/src/convmerge/adapters/chat.py
+++ b/src/convmerge/adapters/chat.py
@@ -1,0 +1,205 @@
+"""Auto-detecting chat adapter.
+
+Routes a raw record to the right internal shape by looking at which keys are
+present. Handles the common messy shapes seen across SFT datasets:
+
+- ``messages`` / ``conversation`` / ``conversations`` lists with
+  ``{role, content}`` or ``{from, value}`` entries.
+- Pairwise preference rows (``conversation_a`` / ``conversation_b``), with an
+  optional ``winner`` field; emits only the winner branch by default.
+- Plain ``text`` strings (yielded as a single assistant message).
+- Alpaca-style ``instruction`` / ``input`` / ``output`` (delegates to the
+  existing alpaca adapter).
+
+Users can override the key lists and role map to teach it about bespoke schemas
+without writing a new adapter from scratch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from convmerge.adapters.alpaca import iter_from_alpaca_line
+from convmerge.models import ChatMessage, TrainingExample
+
+# Default mapping from common ShareGPT-style ``from`` values onto standard roles.
+DEFAULT_ROLE_MAP: dict[str, str] = {
+    "human": "user",
+    "user": "user",
+    "gpt": "assistant",
+    "assistant": "assistant",
+    "bing": "assistant",
+    "bot": "assistant",
+    "system": "system",
+}
+
+# Keys searched for the chat-list container, in priority order.
+DEFAULT_CONVERSATION_KEYS: tuple[str, ...] = ("messages", "conversation", "conversations")
+
+# Keys treated as role labels inside a chat-list entry.
+DEFAULT_ROLE_KEYS: tuple[str, ...] = ("role", "from")
+
+# Keys treated as message content inside a chat-list entry.
+DEFAULT_CONTENT_KEYS: tuple[str, ...] = ("content", "value", "text")
+
+
+def iter_from_chat_line(
+    record: dict[str, Any],
+    *,
+    conversation_keys: tuple[str, ...] = DEFAULT_CONVERSATION_KEYS,
+    role_keys: tuple[str, ...] = DEFAULT_ROLE_KEYS,
+    content_keys: tuple[str, ...] = DEFAULT_CONTENT_KEYS,
+    role_map: dict[str, str] | None = None,
+    pairwise_mode: str = "winner",
+    instruction_keys: tuple[str, ...] = ("instruction", "question", "prompt"),
+    output_keys: tuple[str, ...] = ("output", "response", "answer"),
+    input_keys: tuple[str, ...] = ("input", "context"),
+) -> Iterator[TrainingExample]:
+    """Yield zero or more :class:`TrainingExample` from a single raw record.
+
+    ``pairwise_mode`` controls how ``conversation_a`` / ``conversation_b`` rows
+    are handled:
+
+    - ``"winner"`` (default): emit only the branch named by the ``winner`` field;
+      emit nothing when ``winner`` is absent or unrecognised.
+    - ``"both"``: emit both branches as independent examples.
+    - ``"a"`` / ``"b"``: always emit the chosen branch.
+    """
+    role_map = role_map or DEFAULT_ROLE_MAP
+
+    if "conversation_a" in record and "conversation_b" in record:
+        yield from _iter_pairwise(
+            record,
+            role_keys=role_keys,
+            content_keys=content_keys,
+            role_map=role_map,
+            pairwise_mode=pairwise_mode,
+        )
+        return
+
+    for key in conversation_keys:
+        convs = record.get(key)
+        if isinstance(convs, list) and convs:
+            msgs = _coerce_messages(
+                convs, role_keys=role_keys, content_keys=content_keys, role_map=role_map
+            )
+            if msgs:
+                yield TrainingExample(messages=msgs, meta={"source": "chat"})
+            return
+
+    txt = record.get("text")
+    if isinstance(txt, str) and txt.strip():
+        yield TrainingExample(
+            messages=[ChatMessage(role="assistant", content=txt.strip())],
+            meta={"source": "chat:text"},
+        )
+        return
+
+    # Fall back to the alpaca adapter, but let callers override the key priority.
+    remapped = _remap_for_alpaca(record, instruction_keys, input_keys, output_keys)
+    if remapped is not None:
+        yield from iter_from_alpaca_line(remapped)
+
+
+def _iter_pairwise(
+    record: dict[str, Any],
+    *,
+    role_keys: tuple[str, ...],
+    content_keys: tuple[str, ...],
+    role_map: dict[str, str],
+    pairwise_mode: str,
+) -> Iterator[TrainingExample]:
+    a = record.get("conversation_a")
+    b = record.get("conversation_b")
+    winner = str(record.get("winner") or "").lower().strip()
+
+    branches: list[tuple[str, Any]] = []
+    if pairwise_mode == "both":
+        branches = [("a", a), ("b", b)]
+    elif pairwise_mode == "a":
+        branches = [("a", a)]
+    elif pairwise_mode == "b":
+        branches = [("b", b)]
+    elif pairwise_mode == "winner":
+        if winner in ("model_a", "a"):
+            branches = [("a", a)]
+        elif winner in ("model_b", "b"):
+            branches = [("b", b)]
+        # Tie / unknown: emit nothing.
+    else:
+        raise ValueError(
+            f"Unknown pairwise_mode {pairwise_mode!r}. Use 'winner', 'both', 'a', or 'b'."
+        )
+
+    for label, convs in branches:
+        if not isinstance(convs, list) or not convs:
+            continue
+        msgs = _coerce_messages(
+            convs, role_keys=role_keys, content_keys=content_keys, role_map=role_map
+        )
+        if msgs:
+            yield TrainingExample(
+                messages=msgs,
+                meta={"source": "chat:pairwise", "branch": label},
+            )
+
+
+def _coerce_messages(
+    convs: list[Any],
+    *,
+    role_keys: tuple[str, ...],
+    content_keys: tuple[str, ...],
+    role_map: dict[str, str],
+) -> list[ChatMessage]:
+    out: list[ChatMessage] = []
+    for item in convs:
+        if not isinstance(item, dict):
+            continue
+        role_raw: str | None = None
+        for rk in role_keys:
+            v = item.get(rk)
+            if isinstance(v, str) and v.strip():
+                role_raw = v.strip().lower()
+                break
+        if role_raw is None:
+            continue
+        role = role_map.get(role_raw, role_raw)
+
+        content: str | None = None
+        for ck in content_keys:
+            v = item.get(ck)
+            if isinstance(v, str):
+                content = v
+                break
+        if content is None:
+            continue
+        out.append(ChatMessage(role=role, content=content))
+    return out
+
+
+def _remap_for_alpaca(
+    record: dict[str, Any],
+    instruction_keys: tuple[str, ...],
+    input_keys: tuple[str, ...],
+    output_keys: tuple[str, ...],
+) -> dict[str, Any] | None:
+    """Pick the first matching key for each slot and return a standard alpaca row."""
+    instr = _first_string(record, instruction_keys)
+    out = _first_string(record, output_keys)
+    if instr is None and out is None:
+        return None
+    inp = _first_string(record, input_keys) or ""
+    return {
+        "instruction": instr or "",
+        "input": inp,
+        "output": out or "",
+    }
+
+
+def _first_string(record: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for k in keys:
+        v = record.get(k)
+        if isinstance(v, str) and v.strip():
+            return v
+    return None

--- a/src/convmerge/cli.py
+++ b/src/convmerge/cli.py
@@ -3,79 +3,366 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
 from convmerge import __version__
 from convmerge.convert import convert_file
 
+FETCH_FILE_EXTENSIONS = (".parquet", ".json", ".jsonl")
 
-def main() -> None:
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "convert":
+        _cmd_convert(args)
+    elif args.command == "normalize":
+        _cmd_normalize(args)
+    elif args.command == "dedupe":
+        _cmd_dedupe(args)
+    elif args.command == "turns":
+        _cmd_turns(args)
+    elif args.command == "fetch":
+        _cmd_fetch(args)
+    else:  # pragma: no cover - argparse enforces ``required=True``
+        parser.error(f"unknown command: {args.command}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="convmerge",
-        description="Merge heterogeneous chat/text sources into a single LLM training format.",
+        description=(
+            "Fetch, normalize, and convert heterogeneous chat/instruct datasets "
+            "into a single LLM training format."
+        ),
     )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"%(prog)s {__version__}",
-    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    subparsers = parser.add_subparsers(dest="command", required=True)
 
-    subparsers = parser.add_subparsers(dest="command", help="Command", required=True)
+    _add_convert(subparsers)
+    _add_normalize(subparsers)
+    _add_dedupe(subparsers)
+    _add_turns(subparsers)
+    _add_fetch(subparsers)
 
-    convert_p = subparsers.add_parser(
+    return parser
+
+
+def _add_convert(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
         "convert",
         help="Convert a JSONL file using a source adapter and output format",
     )
-    convert_p.add_argument(
-        "--input",
-        "-i",
-        type=Path,
-        required=True,
-        help="Input JSONL path (one JSON object per line)",
-    )
-    convert_p.add_argument(
-        "--output",
-        "-o",
-        type=Path,
-        required=True,
-        help="Output JSONL path",
-    )
-    convert_p.add_argument(
+    p.add_argument("--input", "-i", type=Path, required=True, help="Input JSONL path")
+    p.add_argument("--output", "-o", type=Path, required=True, help="Output JSONL path")
+    p.add_argument(
         "--from",
         dest="adapter",
         required=True,
         metavar="ADAPTER",
-        help="Source adapter: alpaca, sharegpt, ...",
+        help="Source adapter: alpaca, sharegpt, chat, auto",
     )
-    convert_p.add_argument(
+    p.add_argument(
         "--format",
         "-f",
         dest="output_format",
         required=True,
         metavar="FORMAT",
-        help="Output format: messages, alpaca, ...",
+        help="Output format: messages, alpaca",
     )
-    convert_p.add_argument(
-        "--encoding",
-        default="utf-8",
-        help="File encoding (default: utf-8)",
+    p.add_argument("--encoding", default="utf-8", help="File encoding (default: utf-8)")
+
+
+def _cmd_convert(args: argparse.Namespace) -> None:
+    if not args.input.is_file():
+        print(f"error: input file not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+    n_in, n_out = convert_file(
+        args.input,
+        args.output,
+        adapter_name=args.adapter,
+        output_format=args.output_format,
+        encoding=args.encoding,
+    )
+    print(f"read {n_in} lines, wrote {n_out} examples", file=sys.stderr)
+
+
+def _add_normalize(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "normalize",
+        help="Normalize parquet/json/jsonl files in a directory into clean JSONL",
+    )
+    p.add_argument("--input", "-i", type=Path, required=True, help="Input file or directory")
+    p.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        required=True,
+        help="Output file (when --input is a file) or directory",
     )
 
-    args = parser.parse_args()
 
-    if args.command == "convert":
-        if not args.input.is_file():
-            print(f"error: input file not found: {args.input}", file=sys.stderr)
-            sys.exit(1)
-        n_in, n_out = convert_file(
+def _cmd_normalize(args: argparse.Namespace) -> None:
+    src: Path = args.input
+    dst: Path = args.output
+
+    if src.is_file():
+        n = _normalize_one_file(src, dst)
+        print(f"{src} -> {dst}: {n} records", file=sys.stderr)
+        return
+
+    if not src.is_dir():
+        print(f"error: input not found: {src}", file=sys.stderr)
+        sys.exit(1)
+
+    total_files = 0
+    total_rows = 0
+    for in_path in sorted(src.rglob("*")):
+        if not in_path.is_file():
+            continue
+        if in_path.suffix.lower() not in FETCH_FILE_EXTENSIONS:
+            continue
+        rel = in_path.relative_to(src).with_suffix(".jsonl")
+        out_path = dst / rel
+        try:
+            n = _normalize_one_file(in_path, out_path)
+        except Exception as e:  # noqa: BLE001
+            print(f"[fail] {in_path}: {type(e).__name__}: {e}", file=sys.stderr)
+            continue
+        total_files += 1
+        total_rows += n
+        print(f"[ok] {in_path} -> {out_path} ({n} records)", file=sys.stderr)
+    print(f"[done] {total_files} files, {total_rows} records", file=sys.stderr)
+
+
+def _normalize_one_file(src: Path, dst: Path) -> int:
+    # Imported lazily so that ``convmerge convert`` works without the
+    # ``parquet`` extra when no parquet files are touched.
+    from convmerge.normalize.jsonl import normalize_to_jsonl
+
+    suffix = src.suffix.lower()
+    if suffix == ".parquet":
+        from convmerge.normalize.parquet import parquet_to_jsonl
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        return parquet_to_jsonl(src, dst)
+    return normalize_to_jsonl(src, dst)
+
+
+def _add_dedupe(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("dedupe", help="Remove duplicate rows from a JSONL file")
+    p.add_argument("--input", "-i", type=Path, required=True)
+    p.add_argument("--output", "-o", type=Path, required=True)
+    p.add_argument(
+        "--keys",
+        nargs="+",
+        default=None,
+        help="Only hash these top-level keys (defaults to the whole record)",
+    )
+    p.add_argument("--algorithm", default="md5", choices=("md5", "sha256"))
+
+
+def _cmd_dedupe(args: argparse.Namespace) -> None:
+    from convmerge.normalize.dedup import deduplicate_jsonl
+
+    total, kept = deduplicate_jsonl(
+        args.input,
+        args.output,
+        keys=args.keys,
+        algorithm=args.algorithm,
+    )
+    removed = total - kept
+    pct = (removed / total * 100) if total else 0.0
+    print(
+        f"total={total:,} kept={kept:,} removed={removed:,} ({pct:.2f}%)",
+        file=sys.stderr,
+    )
+
+
+def _add_turns(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "turns",
+        help="Analyze turn distribution of a messages-style JSONL file, optionally splitting it",
+    )
+    p.add_argument("--input", "-i", type=Path, required=True)
+    p.add_argument("--single-out", type=Path, default=None)
+    p.add_argument("--multi-out", type=Path, default=None)
+
+
+def _cmd_turns(args: argparse.Namespace) -> None:
+    from convmerge.normalize.turns import analyze_turn_distribution, split_by_turns
+
+    report = analyze_turn_distribution(args.input)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+    if args.single_out and args.multi_out:
+        s, m = split_by_turns(
             args.input,
-            args.output,
-            adapter_name=args.adapter,
-            output_format=args.output_format,
-            encoding=args.encoding,
+            single_out=args.single_out,
+            multi_out=args.multi_out,
         )
-        print(f"read {n_in} lines, wrote {n_out} examples", file=sys.stderr)
+        print(f"split: single={s:,} -> {args.single_out}", file=sys.stderr)
+        print(f"split: multi ={m:,} -> {args.multi_out}", file=sys.stderr)
+    elif bool(args.single_out) != bool(args.multi_out):
+        print(
+            "error: --single-out and --multi-out must be given together",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _add_fetch(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "fetch",
+        help=(
+            "Fetch training data via a YAML manifest, or a single "
+            "hf://org/dataset / GitHub URL shortcut"
+        ),
+    )
+    p.add_argument(
+        "source",
+        help="Path to a manifest YAML, an 'hf://org/dataset' URI, or a GitHub URL",
+    )
+    p.add_argument("--output", "-o", type=Path, default=None, help="Output root directory")
+    p.add_argument("--hf-token", default=None)
+    p.add_argument("--github-token", default=None)
+    p.add_argument("--only", nargs="+", default=None, help="Manifest mode: fetch only these names")
+    p.add_argument(
+        "--on-error",
+        choices=("continue", "fail"),
+        default=None,
+        help="Override manifest defaults.on_error",
+    )
+    p.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Re-download even when the output already exists",
+    )
+    # Shortcut-only flags (ignored in manifest mode)
+    p.add_argument("--ext", nargs="+", default=None, help="GitHub URL mode: extension filter")
+    p.add_argument("--mode", choices=("tree", "clone"), default=None)
+    p.add_argument("--lfs", action="store_true")
+    p.add_argument("--split", default=None, help="hf:// shortcut: dataset split")
+    p.add_argument("--config", default=None, help="hf:// shortcut: dataset config")
+
+
+def _cmd_fetch(args: argparse.Namespace) -> None:
+    source = args.source
+
+    if source.startswith("hf://") or source.startswith("https://") or source.startswith("http://"):
+        _cmd_fetch_shortcut(args, source)
+        return
+
+    manifest_path = Path(source)
+    if not manifest_path.is_file():
+        print(
+            f"error: manifest file not found: {manifest_path}\n"
+            "Pass either a YAML manifest path, an hf://org/dataset URI, or a GitHub URL.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    from convmerge.fetch.manifest import Defaults, load_manifest
+    from convmerge.fetch.runner import run_manifest
+
+    manifest = load_manifest(manifest_path)
+    if args.on_error is not None or args.no_resume:
+        manifest = _with_overridden_defaults(
+            manifest,
+            on_error=args.on_error,
+            resume=False if args.no_resume else None,
+        )
+
+    result = run_manifest(
+        manifest,
+        output_root=args.output,
+        only=args.only,
+        hf_token=args.hf_token,
+        github_token=args.github_token,
+    )
+    # Propagate failure when requested.
+    if manifest.defaults.on_error == "fail" and result.failed:
+        sys.exit(1)
+
+    # Defaults reference for type checker.
+    _ = Defaults
+
+
+def _cmd_fetch_shortcut(args: argparse.Namespace, source: str) -> None:
+    out_root = args.output or Path("./raw")
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    if source.startswith("hf://"):
+        from convmerge.fetch.hf import download_hf_dataset
+        from convmerge.fetch.manifest import sanitize_name
+
+        dataset_id = source[len("hf://") :]
+        dst = out_root / f"{sanitize_name(dataset_id)}.jsonl"
+        download_hf_dataset(
+            dataset_id,
+            dst,
+            config=args.config,
+            split=args.split,
+            token=args.hf_token,
+        )
+        print(f"[ok] {dataset_id} -> {dst}", file=sys.stderr)
+        return
+
+    # http(s):// shortcuts
+    from convmerge.fetch.git import clone_repo
+    from convmerge.fetch.github import download_raw_file, fetch_repo_tree_files
+    from convmerge.fetch.manifest import sanitize_name
+
+    lowered = source.lower()
+    name = sanitize_name(lowered.rstrip("/").rsplit("/", 1)[-1] or "fetch")
+
+    if "raw.githubusercontent.com" in lowered or lowered.endswith(
+        (".json", ".jsonl", ".json.gz")
+    ):
+        suffix = ".jsonl"
+        for s in (".json.gz", ".jsonl", ".json"):
+            if lowered.endswith(s):
+                suffix = s
+                break
+        dst = out_root / f"{name}{suffix}"
+        download_raw_file(source, dst, token=args.github_token)
+        print(f"[ok] {source} -> {dst}", file=sys.stderr)
+        return
+
+    if "github.com" in lowered:
+        dst = out_root / name
+        if args.mode == "clone":
+            clone_repo(source, dst, token=args.github_token, lfs=args.lfs)
+        else:
+            fetch_repo_tree_files(
+                source,
+                dst,
+                ext=tuple(args.ext or ()),
+                token=args.github_token,
+            )
+        print(f"[ok] {source} -> {dst}", file=sys.stderr)
+        return
+
+    print(
+        f"error: unsupported URL: {source!r}. "
+        "Only hf://, raw.githubusercontent.com, and github.com are supported.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _with_overridden_defaults(manifest, *, on_error, resume):
+    from dataclasses import replace
+
+    new_defaults = manifest.defaults
+    if on_error is not None:
+        new_defaults = replace(new_defaults, on_error=on_error)
+    if resume is not None:
+        new_defaults = replace(new_defaults, resume=resume)
+    return replace(manifest, defaults=new_defaults)
 
 
 if __name__ == "__main__":

--- a/src/convmerge/cli.py
+++ b/src/convmerge/cli.py
@@ -319,9 +319,7 @@ def _cmd_fetch_shortcut(args: argparse.Namespace, source: str) -> None:
     lowered = source.lower()
     name = sanitize_name(lowered.rstrip("/").rsplit("/", 1)[-1] or "fetch")
 
-    if "raw.githubusercontent.com" in lowered or lowered.endswith(
-        (".json", ".jsonl", ".json.gz")
-    ):
+    if "raw.githubusercontent.com" in lowered or lowered.endswith((".json", ".jsonl", ".json.gz")):
         suffix = ".jsonl"
         for s in (".json.gz", ".jsonl", ".json"):
             if lowered.endswith(s):

--- a/src/convmerge/fetch/__init__.py
+++ b/src/convmerge/fetch/__init__.py
@@ -1,0 +1,38 @@
+"""YAML-manifest driven fetcher for HuggingFace + GitHub training data.
+
+Requires the ``fetch`` extra (``pip install 'convmerge[fetch]'``). HuggingFace
+entries additionally require the ``fetch-hf`` extra, which adds ``datasets``.
+
+Public API is intentionally small: parse a manifest, iterate entries, each
+writes files under ``output_root/<sanitised_name>/``. Single-dataset wrappers
+are not provided on purpose: if you only need one HF dataset, call
+``datasets.load_dataset`` directly.
+"""
+
+from __future__ import annotations
+
+from convmerge.fetch.auth import AuthConfig, TokenSpec, redact_url, resolve_token
+from convmerge.fetch.manifest import (
+    DatasetEntry,
+    Defaults,
+    Manifest,
+    classify_entry,
+    load_manifest,
+    sanitize_name,
+)
+from convmerge.fetch.runner import FetchResult, run_manifest
+
+__all__ = [
+    "AuthConfig",
+    "DatasetEntry",
+    "Defaults",
+    "FetchResult",
+    "Manifest",
+    "TokenSpec",
+    "classify_entry",
+    "load_manifest",
+    "redact_url",
+    "resolve_token",
+    "run_manifest",
+    "sanitize_name",
+]

--- a/src/convmerge/fetch/auth.py
+++ b/src/convmerge/fetch/auth.py
@@ -1,0 +1,62 @@
+"""Token resolution and redaction helpers.
+
+Tokens may be supplied three ways, in priority order:
+
+1. An explicit value passed to ``resolve_token(explicit=...)`` (e.g. from CLI).
+2. The contents of a file at ``TokenSpec.file``.
+3. The environment variable named by ``TokenSpec.env``.
+
+Tokens never appear in plan output, URLs, or logs; use :func:`redact_url` when
+echoing any URL that might have embedded credentials.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TokenSpec:
+    """Where to look for a single token."""
+
+    env: str | None = None
+    file: str | None = None
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    """Auth block parsed from the YAML manifest's ``auth`` section."""
+
+    hf: TokenSpec = TokenSpec()
+    github: TokenSpec = TokenSpec()
+
+
+def resolve_token(spec: TokenSpec, *, explicit: str | None = None) -> str | None:
+    """Return the first non-empty token from (explicit, file, env), or ``None``."""
+    if explicit is not None:
+        val = explicit.strip()
+        if val:
+            return val
+    if spec.file:
+        p = Path(spec.file).expanduser()
+        if p.is_file():
+            val = p.read_text(encoding="utf-8").strip()
+            if val:
+                return val
+    if spec.env:
+        val = (os.environ.get(spec.env) or "").strip()
+        if val:
+            return val
+    return None
+
+
+# Pattern matches a userinfo section in an HTTPS URL (``user:token@host``).
+_USERINFO_RE = re.compile(r"(https?://)[^/@\s]+@")
+
+
+def redact_url(url: str) -> str:
+    """Remove any ``user:token@`` userinfo from ``url`` for safe logging."""
+    return _USERINFO_RE.sub(r"\1", url)

--- a/src/convmerge/fetch/git.py
+++ b/src/convmerge/fetch/git.py
@@ -1,0 +1,71 @@
+"""Thin wrapper over the system ``git`` (and optional ``git-lfs``) binaries."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+class GitNotFoundError(RuntimeError):
+    """Raised when ``git`` is required but not installed on PATH."""
+
+
+class GitLfsNotFoundError(RuntimeError):
+    """Raised when ``git-lfs`` is requested via ``lfs: true`` but not installed."""
+
+
+def clone_repo(
+    url: str,
+    dst_dir: str | Path,
+    *,
+    token: str | None = None,
+    lfs: bool = False,
+) -> Path:
+    """Clone ``url`` into ``dst_dir`` (or ``git pull`` if it is already a repo).
+
+    When ``token`` is provided and the URL targets ``github.com`` / HuggingFace,
+    it is injected as the HTTPS basic-auth password for the clone call and
+    **never** logged. For any other host the token is ignored.
+    """
+    if shutil.which("git") is None:
+        raise GitNotFoundError(
+            "git binary not found on PATH. Install git to use 'mode: clone' entries."
+        )
+
+    dst = Path(dst_dir)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+    if (dst / ".git").is_dir():
+        _run(["git", "-C", str(dst), "pull", "--ff-only"])
+    else:
+        clone_url = _maybe_inject_token(url, token)
+        _run(["git", "clone", clone_url, str(dst)])
+
+    if lfs:
+        if shutil.which("git-lfs") is None:
+            raise GitLfsNotFoundError(
+                "git-lfs binary not found on PATH but entry requested lfs: true. "
+                "Install git-lfs or drop the flag."
+            )
+        _run(["git", "-C", str(dst), "lfs", "pull"])
+
+    return dst
+
+
+def _maybe_inject_token(url: str, token: str | None) -> str:
+    if not token:
+        return url
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower()
+    if "github.com" not in host and "huggingface.co" not in host:
+        return url
+    scheme = parsed.scheme or "https"
+    # ``user:`` is ignored by both hosts; the token acts as the password.
+    auth_netloc = f"user:{token}@{parsed.netloc}"
+    return f"{scheme}://{auth_netloc}{parsed.path}"
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)

--- a/src/convmerge/fetch/github.py
+++ b/src/convmerge/fetch/github.py
@@ -1,0 +1,123 @@
+"""GitHub fetchers: single raw URL + recursive Trees API with extension filter.
+
+Uses stdlib ``urllib.request`` so core stays dependency-free; only PyYAML is
+needed for manifest parsing (``[fetch]`` extra).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+_GITHUB_REPO_RE = re.compile(
+    r"^https?://(?:www\.)?github\.com/(?P<owner>[^/]+)/(?P<repo>[^/?#]+?)(?:\.git)?(?:/.*)?$"
+)
+
+_DEFAULT_TIMEOUT = 60
+
+
+class GitHubFetchError(RuntimeError):
+    """Raised when a GitHub API or download call fails."""
+
+
+def download_raw_file(url: str, dst: str | Path, *, token: str | None = None) -> Path:
+    """Download one raw URL (``raw.githubusercontent.com`` or similar) to ``dst``.
+
+    Parent directories are created. Any ``Authorization`` header is only sent
+    when ``token`` is provided.
+    """
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"token {token}")
+    req.add_header("User-Agent", "convmerge-fetch/0.2")
+
+    try:
+        with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT) as resp:
+            data = resp.read()
+    except urllib.error.HTTPError as e:
+        raise GitHubFetchError(f"HTTP {e.code} fetching {url}: {e.reason}") from e
+    except urllib.error.URLError as e:
+        raise GitHubFetchError(f"Network error fetching {url}: {e.reason}") from e
+
+    dst_p.write_bytes(data)
+    return dst_p
+
+
+def parse_repo_url(url: str) -> tuple[str, str]:
+    """Return ``(owner, repo)`` for a ``github.com/owner/repo`` URL."""
+    m = _GITHUB_REPO_RE.match(url.strip())
+    if not m:
+        raise ValueError(f"Not a GitHub repo URL: {url!r}")
+    return m.group("owner"), m.group("repo")
+
+
+def fetch_repo_tree_files(
+    repo_url: str,
+    dst_dir: str | Path,
+    *,
+    ext: tuple[str, ...] = (),
+    token: str | None = None,
+    branch: str | None = None,
+) -> list[Path]:
+    """Pull files from a GitHub repo via the Trees API (no full clone).
+
+    Only files whose lowered path ends with one of ``ext`` are downloaded. When
+    ``ext`` is empty, every blob in the tree is downloaded (use with care for
+    large repos). Returns the list of downloaded file paths.
+    """
+    owner, repo = parse_repo_url(repo_url)
+    dst = Path(dst_dir)
+    dst.mkdir(parents=True, exist_ok=True)
+
+    if branch is None:
+        branch = _get_default_branch(owner, repo, token=token)
+
+    tree = _get_tree(owner, repo, branch, token=token)
+    ext_lower = tuple(e.lower() for e in ext)
+
+    out: list[Path] = []
+    raw_base = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/"
+    for node in tree.get("tree", []):
+        if node.get("type") != "blob":
+            continue
+        path = node.get("path") or ""
+        if ext_lower and not any(path.lower().endswith(e) for e in ext_lower):
+            continue
+        # Mirror repo hierarchy on disk but replace separators so the caller
+        # gets a flat, file-manager-friendly directory when requested.
+        local_name = path.replace("/", "_")
+        dest = dst / local_name
+        download_raw_file(raw_base + path, dest, token=token)
+        out.append(dest)
+    return out
+
+
+def _get_default_branch(owner: str, repo: str, *, token: str | None) -> str:
+    data = _github_api_json(f"https://api.github.com/repos/{owner}/{repo}", token=token)
+    return data.get("default_branch") or "main"
+
+
+def _get_tree(owner: str, repo: str, branch: str, *, token: str | None) -> dict:
+    url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1"
+    return _github_api_json(url, token=token)
+
+
+def _github_api_json(url: str, *, token: str | None) -> dict:
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github.v3+json")
+    req.add_header("User-Agent", "convmerge-fetch/0.2")
+    if token:
+        req.add_header("Authorization", f"token {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        raise GitHubFetchError(f"HTTP {e.code} calling {url}: {e.reason}") from e
+    except urllib.error.URLError as e:
+        raise GitHubFetchError(f"Network error calling {url}: {e.reason}") from e

--- a/src/convmerge/fetch/hf.py
+++ b/src/convmerge/fetch/hf.py
@@ -1,0 +1,47 @@
+"""HuggingFace fetcher.
+
+A deliberately thin wrapper around ``datasets.load_dataset(...).to_json(...)``.
+We never reimplement dataset loading; if you only need one dataset, call
+``datasets.load_dataset`` directly in your own code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def download_hf_dataset(
+    dataset_id: str,
+    dst_path: str | Path,
+    *,
+    config: str | None = None,
+    split: str | None = None,
+    token: str | None = None,
+) -> Path:
+    """Load a HuggingFace dataset and dump it to a JSONL file.
+
+    ``config`` and ``split`` default to ``None`` / ``"train"``, which matches
+    the shape of most SFT datasets. Raises ``ImportError`` with an install hint
+    when the ``datasets`` package is missing.
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError as e:
+        raise ImportError(
+            "HuggingFace entries require the 'datasets' package. "
+            "Install with: pip install 'convmerge[fetch-hf]'"
+        ) from e
+
+    dst = Path(dst_path)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+    load_kwargs: dict[str, object] = {}
+    if config is not None:
+        load_kwargs["name"] = config
+    load_kwargs["split"] = split or "train"
+    if token:
+        load_kwargs["token"] = token
+
+    ds = load_dataset(dataset_id, **load_kwargs)
+    ds.to_json(str(dst))
+    return dst

--- a/src/convmerge/fetch/manifest.py
+++ b/src/convmerge/fetch/manifest.py
@@ -1,0 +1,181 @@
+"""Parse and validate the YAML manifest that drives ``convmerge fetch``."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from convmerge.fetch.auth import AuthConfig, TokenSpec
+
+EntryKind = Literal["hf", "url_raw", "url_github_tree", "url_github_clone"]
+
+
+@dataclass(frozen=True)
+class DatasetEntry:
+    """One ``datasets[*]`` entry from the manifest."""
+
+    name: str
+    # Either ``hf`` or ``url`` is set. Others are optional modifiers.
+    hf: str | None = None
+    url: str | None = None
+
+    # HuggingFace only
+    config: str | None = None
+    split: str | None = None
+
+    # GitHub repo only
+    ext: tuple[str, ...] = ()
+    mode: Literal["tree", "clone"] | None = None
+    lfs: bool = False
+
+    # Optional output override (directory relative to manifest or absolute).
+    output: str | None = None
+
+
+@dataclass(frozen=True)
+class Defaults:
+    """Manifest-wide defaults applied when an entry does not override them."""
+
+    output_root: str = "./raw"
+    on_error: Literal["continue", "fail"] = "continue"
+    resume: bool = True
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Parsed top-level manifest."""
+
+    version: int = 1
+    auth: AuthConfig = field(default_factory=AuthConfig)
+    defaults: Defaults = field(default_factory=Defaults)
+    datasets: tuple[DatasetEntry, ...] = ()
+
+
+_SANITIZE_BAD_CHARS = re.compile(r'[<>:"/\\|?*]')
+_SANITIZE_WHITESPACE = re.compile(r"\s+")
+
+
+def sanitize_name(name: str) -> str:
+    """Turn an arbitrary dataset name into a safe file/directory name."""
+    s = _SANITIZE_BAD_CHARS.sub("_", name)
+    s = _SANITIZE_WHITESPACE.sub("_", s).strip("_")
+    return s or "unnamed"
+
+
+def load_manifest(path: str | Path) -> Manifest:
+    """Parse a YAML manifest file into a :class:`Manifest`.
+
+    Raises ``ImportError`` with an install hint if PyYAML is not available.
+    """
+    try:
+        import yaml
+    except ImportError as e:
+        raise ImportError(
+            "pyyaml is required for fetch manifests. "
+            "Install with: pip install 'convmerge[fetch]'"
+        ) from e
+
+    with open(path, encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"Manifest root must be a mapping, got {type(raw).__name__}")
+    return _from_dict(raw)
+
+
+def _from_dict(raw: dict[str, Any]) -> Manifest:
+    version = int(raw.get("version", 1))
+    if version != 1:
+        raise ValueError(
+            f"Unsupported manifest version: {version}. This build understands version 1."
+        )
+
+    auth_raw = raw.get("auth") or {}
+    auth = AuthConfig(
+        hf=TokenSpec(env=auth_raw.get("hf_token_env"), file=auth_raw.get("hf_token_file")),
+        github=TokenSpec(
+            env=auth_raw.get("github_token_env"),
+            file=auth_raw.get("github_token_file"),
+        ),
+    )
+
+    d_raw = raw.get("defaults") or {}
+    on_error = d_raw.get("on_error", "continue")
+    if on_error not in ("continue", "fail"):
+        raise ValueError(f"defaults.on_error must be 'continue' or 'fail', got {on_error!r}")
+    defaults = Defaults(
+        output_root=str(d_raw.get("output_root", "./raw")),
+        on_error=on_error,
+        resume=bool(d_raw.get("resume", True)),
+    )
+
+    entries_raw = raw.get("datasets") or []
+    if not isinstance(entries_raw, list):
+        raise ValueError("'datasets' must be a list")
+    entries: list[DatasetEntry] = []
+    for i, item in enumerate(entries_raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"datasets[{i}] must be a mapping")
+        entries.append(_entry_from_dict(item, index=i))
+
+    return Manifest(version=version, auth=auth, defaults=defaults, datasets=tuple(entries))
+
+
+def _entry_from_dict(item: dict[str, Any], *, index: int) -> DatasetEntry:
+    name = item.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(f"datasets[{index}].name is required and must be a non-empty string")
+
+    hf = item.get("hf")
+    url = item.get("url")
+    if bool(hf) == bool(url):
+        raise ValueError(
+            f"datasets[{index}] ({name!r}) must set exactly one of 'hf' or 'url'"
+        )
+
+    ext_raw = item.get("ext") or ()
+    if isinstance(ext_raw, str):
+        ext_raw = (ext_raw,)
+    ext = tuple(str(e).lower() for e in ext_raw)
+
+    mode = item.get("mode")
+    if mode not in (None, "tree", "clone"):
+        raise ValueError(
+            f"datasets[{index}] ({name!r}) mode must be 'tree' or 'clone', got {mode!r}"
+        )
+
+    return DatasetEntry(
+        name=name.strip(),
+        hf=str(hf).strip() if hf else None,
+        url=str(url).strip() if url else None,
+        config=item.get("config"),
+        split=item.get("split"),
+        ext=ext,
+        mode=mode,
+        lfs=bool(item.get("lfs", False)),
+        output=item.get("output"),
+    )
+
+
+_RAW_GITHUB_HOSTS = ("raw.githubusercontent.com",)
+_RAW_SUFFIXES = (".json", ".jsonl", ".json.gz")
+
+
+def classify_entry(entry: DatasetEntry) -> EntryKind:
+    """Decide which fetch backend handles this entry."""
+    if entry.hf:
+        return "hf"
+    url = (entry.url or "").lower()
+    if not url:
+        raise ValueError(f"Entry {entry.name!r} has neither 'hf' nor 'url'")
+    if any(host in url for host in _RAW_GITHUB_HOSTS):
+        return "url_raw"
+    if url.endswith(_RAW_SUFFIXES):
+        return "url_raw"
+    if "github.com" in url:
+        return "url_github_clone" if entry.mode == "clone" else "url_github_tree"
+    raise ValueError(
+        f"Entry {entry.name!r} has URL {entry.url!r}; only GitHub and "
+        "raw GitHub URLs are supported. For HuggingFace use the 'hf' field."
+    )

--- a/src/convmerge/fetch/manifest.py
+++ b/src/convmerge/fetch/manifest.py
@@ -73,8 +73,7 @@ def load_manifest(path: str | Path) -> Manifest:
         import yaml
     except ImportError as e:
         raise ImportError(
-            "pyyaml is required for fetch manifests. "
-            "Install with: pip install 'convmerge[fetch]'"
+            "pyyaml is required for fetch manifests. Install with: pip install 'convmerge[fetch]'"
         ) from e
 
     with open(path, encoding="utf-8") as f:
@@ -130,9 +129,7 @@ def _entry_from_dict(item: dict[str, Any], *, index: int) -> DatasetEntry:
     hf = item.get("hf")
     url = item.get("url")
     if bool(hf) == bool(url):
-        raise ValueError(
-            f"datasets[{index}] ({name!r}) must set exactly one of 'hf' or 'url'"
-        )
+        raise ValueError(f"datasets[{index}] ({name!r}) must set exactly one of 'hf' or 'url'")
 
     ext_raw = item.get("ext") or ()
     if isinstance(ext_raw, str):

--- a/src/convmerge/fetch/runner.py
+++ b/src/convmerge/fetch/runner.py
@@ -76,9 +76,7 @@ def run_manifest(
             detail = f"{type(e).__name__}: {e}"
             trace_tail = traceback.format_exc(limit=2).strip().splitlines()[-1:]
             full = detail + (f" | {trace_tail[0]}" if trace_tail else "")
-            _record_error(
-                result, entry.name, full, on_error=manifest.defaults.on_error, log=log
-            )
+            _record_error(result, entry.name, full, on_error=manifest.defaults.on_error, log=log)
             continue
         result.succeeded.append(entry.name)
 

--- a/src/convmerge/fetch/runner.py
+++ b/src/convmerge/fetch/runner.py
@@ -1,0 +1,215 @@
+"""Iterate a manifest and dispatch each entry to the right backend."""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from convmerge.fetch.auth import AuthConfig, redact_url, resolve_token
+from convmerge.fetch.manifest import (
+    DatasetEntry,
+    EntryKind,
+    Manifest,
+    classify_entry,
+    sanitize_name,
+)
+
+LogFn = Callable[[str], None]
+
+
+@dataclass
+class FetchResult:
+    """Summary returned by :func:`run_manifest`."""
+
+    succeeded: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.succeeded) + len(self.skipped) + len(self.failed)
+
+
+def run_manifest(
+    manifest: Manifest,
+    *,
+    output_root: str | Path | None = None,
+    only: list[str] | None = None,
+    hf_token: str | None = None,
+    github_token: str | None = None,
+    log: LogFn = print,
+) -> FetchResult:
+    """Execute every selected entry in ``manifest`` sequentially.
+
+    ``output_root`` overrides the manifest default when provided. ``only``
+    filters the entries by name. ``hf_token`` / ``github_token`` take highest
+    priority over the manifest ``auth`` block and process env.
+    """
+    base_root = Path(output_root) if output_root else Path(manifest.defaults.output_root)
+    base_root.mkdir(parents=True, exist_ok=True)
+
+    hf_tok = resolve_token(manifest.auth.hf, explicit=hf_token)
+    gh_tok = resolve_token(manifest.auth.github, explicit=github_token)
+
+    entries = _select_entries(manifest.datasets, only)
+    result = FetchResult()
+
+    for entry in entries:
+        dst = _entry_output_path(entry, base_root)
+        try:
+            kind = classify_entry(entry)
+        except ValueError as e:
+            _record_error(result, entry.name, str(e), on_error=manifest.defaults.on_error, log=log)
+            continue
+
+        if manifest.defaults.resume and _already_fetched(dst, kind):
+            log(f"[skip] {entry.name} (already present at {dst})")
+            result.skipped.append(entry.name)
+            continue
+
+        log(f"[fetch] {entry.name} ({kind}) -> {dst}")
+        try:
+            _dispatch(entry, kind, dst, hf_tok=hf_tok, gh_tok=gh_tok)
+        except Exception as e:  # noqa: BLE001  (report, let on_error decide)
+            detail = f"{type(e).__name__}: {e}"
+            trace_tail = traceback.format_exc(limit=2).strip().splitlines()[-1:]
+            full = detail + (f" | {trace_tail[0]}" if trace_tail else "")
+            _record_error(
+                result, entry.name, full, on_error=manifest.defaults.on_error, log=log
+            )
+            continue
+        result.succeeded.append(entry.name)
+
+    log(
+        f"[done] ok={len(result.succeeded)} skipped={len(result.skipped)} "
+        f"failed={len(result.failed)}"
+    )
+    return result
+
+
+def _select_entries(
+    datasets: tuple[DatasetEntry, ...], only: list[str] | None
+) -> list[DatasetEntry]:
+    if not only:
+        return list(datasets)
+    wanted = set(only)
+    matched = [d for d in datasets if d.name in wanted]
+    missing = wanted - {d.name for d in matched}
+    if missing:
+        raise ValueError(f"Unknown dataset name(s) in --only: {sorted(missing)}")
+    return matched
+
+
+def _entry_output_path(entry: DatasetEntry, base_root: Path) -> Path:
+    if entry.output:
+        return Path(entry.output)
+    return base_root / sanitize_name(entry.name)
+
+
+def _already_fetched(dst: Path, kind: EntryKind) -> bool:
+    if kind in ("hf", "url_raw"):
+        # These write a single file (.jsonl / raw). Treat as done if it exists
+        # with non-zero size, or if the parent directory contains a non-empty file
+        # (covers the ``output: dir`` override + default ``{name}.jsonl`` name).
+        if dst.is_file() and dst.stat().st_size > 0:
+            return True
+        if dst.is_dir():
+            return any(p.is_file() and p.stat().st_size > 0 for p in dst.iterdir())
+        parent_file = dst.with_suffix(".jsonl")
+        if parent_file.is_file() and parent_file.stat().st_size > 0:
+            return True
+        return False
+    # Tree / clone produce a directory with one or more files.
+    if not dst.is_dir():
+        return False
+    return any(dst.iterdir())
+
+
+def _dispatch(
+    entry: DatasetEntry,
+    kind: EntryKind,
+    dst: Path,
+    *,
+    hf_tok: str | None,
+    gh_tok: str | None,
+) -> None:
+    if kind == "hf":
+        _run_hf(entry, dst, token=hf_tok)
+        return
+    if kind == "url_raw":
+        _run_raw(entry, dst, token=gh_tok)
+        return
+    if kind == "url_github_tree":
+        _run_tree(entry, dst, token=gh_tok)
+        return
+    if kind == "url_github_clone":
+        _run_clone(entry, dst, token=gh_tok)
+        return
+    raise AssertionError(f"Unhandled entry kind: {kind!r}")
+
+
+def _run_hf(entry: DatasetEntry, dst: Path, *, token: str | None) -> None:
+    from convmerge.fetch.hf import download_hf_dataset
+
+    target = dst if dst.suffix else dst.with_suffix(".jsonl")
+    download_hf_dataset(
+        entry.hf or "",
+        target,
+        config=entry.config,
+        split=entry.split,
+        token=token,
+    )
+
+
+def _run_raw(entry: DatasetEntry, dst: Path, *, token: str | None) -> None:
+    from convmerge.fetch.github import download_raw_file
+
+    url = entry.url or ""
+    suffix = _raw_suffix(url)
+    target = dst if dst.suffix else dst.with_suffix(suffix)
+    download_raw_file(url, target, token=token)
+
+
+def _run_tree(entry: DatasetEntry, dst: Path, *, token: str | None) -> None:
+    from convmerge.fetch.github import fetch_repo_tree_files
+
+    fetch_repo_tree_files(entry.url or "", dst, ext=entry.ext, token=token)
+
+
+def _run_clone(entry: DatasetEntry, dst: Path, *, token: str | None) -> None:
+    from convmerge.fetch.git import clone_repo
+
+    clone_repo(entry.url or "", dst, token=token, lfs=entry.lfs)
+
+
+def _raw_suffix(url: str) -> str:
+    lowered = url.lower()
+    for s in (".json.gz", ".jsonl", ".json"):
+        if lowered.endswith(s):
+            return s
+    return ".jsonl"
+
+
+def _record_error(
+    result: FetchResult,
+    name: str,
+    msg: str,
+    *,
+    on_error: str,
+    log: LogFn,
+) -> None:
+    log(f"[fail] {name}: {msg}")
+    result.failed.append((name, msg))
+    if on_error == "fail":
+        raise RuntimeError(f"Fetch failed for {name!r}: {msg}")
+
+
+# Re-export for testing / external use.
+__all__ = [
+    "AuthConfig",
+    "FetchResult",
+    "redact_url",
+    "run_manifest",
+]

--- a/src/convmerge/normalize/__init__.py
+++ b/src/convmerge/normalize/__init__.py
@@ -1,0 +1,43 @@
+"""Format normalization utilities.
+
+Turn messy chat/instruct dataset files (parquet, JSON arrays, single-line JSONL,
+mixed schemas) into clean newline-delimited JSONL, and provide building blocks
+for turn-count analysis, deduplication, and single-turn <-> multi-turn conversion.
+"""
+
+from __future__ import annotations
+
+from convmerge.normalize.convert_turns import (
+    multi_turn_to_single_turn_record,
+    single_turn_to_multi_turn_record,
+)
+from convmerge.normalize.dedup import deduplicate_jsonl
+from convmerge.normalize.jsonl import (
+    detect_jsonl_shape,
+    iter_json_records,
+    load_jsonl,
+    normalize_to_jsonl,
+)
+from convmerge.normalize.schema import is_uniform_schema, key_frequency
+from convmerge.normalize.turns import (
+    analyze_turn_distribution,
+    count_turns,
+    is_single_turn,
+    split_by_turns,
+)
+
+__all__ = [
+    "analyze_turn_distribution",
+    "count_turns",
+    "deduplicate_jsonl",
+    "detect_jsonl_shape",
+    "is_single_turn",
+    "is_uniform_schema",
+    "iter_json_records",
+    "key_frequency",
+    "load_jsonl",
+    "multi_turn_to_single_turn_record",
+    "normalize_to_jsonl",
+    "single_turn_to_multi_turn_record",
+    "split_by_turns",
+]

--- a/src/convmerge/normalize/convert_turns.py
+++ b/src/convmerge/normalize/convert_turns.py
@@ -1,0 +1,78 @@
+"""Single-turn <-> multi-turn record conversion helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def single_turn_to_multi_turn_record(
+    data: dict[str, Any],
+    *,
+    instruction_key: str = "instruction",
+    input_key: str = "input",
+    output_key: str = "output",
+) -> dict[str, Any] | None:
+    """Turn ``{instruction, input, output}`` into a two-turn messages sample.
+
+    Returns ``None`` when either instruction or output is missing/empty so that
+    partial rows are silently dropped rather than producing garbage messages.
+    """
+    instr = data.get(instruction_key, "")
+    inp = data.get(input_key, "")
+    out = data.get(output_key, "")
+
+    if not isinstance(instr, str) or not instr.strip():
+        return None
+    if not isinstance(out, str) or not out.strip():
+        return None
+
+    if isinstance(inp, str) and inp.strip():
+        user_content = instr.strip() + "\n\n" + inp.strip()
+    else:
+        user_content = instr.strip()
+
+    return {
+        "messages": [
+            {"role": "user", "content": user_content},
+            {"role": "assistant", "content": out.strip()},
+        ]
+    }
+
+
+def multi_turn_to_single_turn_record(
+    data: dict[str, Any],
+    *,
+    joiner: str = "\n",
+) -> dict[str, Any] | None:
+    """Flatten a messages sample into ``{instruction, input, output}``.
+
+    All user messages are joined with ``joiner`` into ``instruction``; the last
+    assistant message becomes ``output``. Returns ``None`` when no assistant
+    turn exists.
+    """
+    msgs = data.get("messages") or []
+    if not isinstance(msgs, list) or not msgs:
+        return None
+
+    user_parts: list[str] = []
+    last_assistant: str | None = None
+    for m in msgs:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        content = m.get("content", "")
+        if not isinstance(content, str):
+            continue
+        if role == "user":
+            user_parts.append(content)
+        elif role == "assistant":
+            last_assistant = content
+
+    if last_assistant is None:
+        return None
+
+    return {
+        "instruction": joiner.join(user_parts).strip(),
+        "input": "",
+        "output": last_assistant.strip(),
+    }

--- a/src/convmerge/normalize/dedup.py
+++ b/src/convmerge/normalize/dedup.py
@@ -1,0 +1,90 @@
+"""Deduplicate JSONL files by hashing a canonical projection of each record."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+HashFn = Callable[[bytes], str]
+
+
+def _md5_hex(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+_BUILTIN_HASHES: dict[str, HashFn] = {
+    "md5": _md5_hex,
+    "sha256": _sha256_hex,
+}
+
+
+def deduplicate_jsonl(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    keys: Iterable[str] | None = None,
+    algorithm: str | HashFn = "md5",
+) -> tuple[int, int]:
+    """Stream ``src`` JSONL into ``dst``, dropping duplicate rows.
+
+    A row's identity is the hash of ``json.dumps(projection, sort_keys=True)``.
+    ``keys`` optionally restricts the projection to the given top-level fields
+    (useful when metadata like ``id`` or timestamps differ but the content is
+    identical). ``algorithm`` may be ``"md5"``, ``"sha256"``, or any callable
+    ``bytes -> str``.
+
+    Returns ``(total_rows, kept_rows)``.
+    """
+    if callable(algorithm):
+        hasher = algorithm
+    else:
+        try:
+            hasher = _BUILTIN_HASHES[algorithm]
+        except KeyError as e:
+            raise ValueError(
+                f"Unknown hash algorithm {algorithm!r}. "
+                f"Choose one of: {sorted(_BUILTIN_HASHES)} or pass a callable."
+            ) from e
+
+    key_set = set(keys) if keys is not None else None
+
+    src_p = Path(src)
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    seen: set[str] = set()
+    total = 0
+    kept = 0
+    with src_p.open(encoding="utf-8") as rf, dst_p.open("w", encoding="utf-8") as wf:
+        for line in rf:
+            line = line.strip()
+            if not line:
+                continue
+            total += 1
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                # Skip corrupt rows silently; caller can re-run normalize first.
+                continue
+            projection = _project(data, key_set)
+            normalized = json.dumps(projection, sort_keys=True, ensure_ascii=False)
+            h = hasher(normalized.encode("utf-8"))
+            if h in seen:
+                continue
+            seen.add(h)
+            wf.write(line + "\n")
+            kept += 1
+    return total, kept
+
+
+def _project(data: Any, keys: set[str] | None) -> Any:
+    if keys is None or not isinstance(data, dict):
+        return data
+    return {k: data[k] for k in keys if k in data}

--- a/src/convmerge/normalize/jsonl.py
+++ b/src/convmerge/normalize/jsonl.py
@@ -40,9 +40,7 @@ def load_jsonl(path: str | Path, *, max_rows: int | None = None) -> list[dict[st
     return out
 
 
-def iter_json_records(
-    path: str | Path, *, max_rows: int | None = None
-) -> Iterator[dict[str, Any]]:
+def iter_json_records(path: str | Path, *, max_rows: int | None = None) -> Iterator[dict[str, Any]]:
     """Iterate dict records from a ``.json`` or ``.jsonl`` file.
 
     For ``.json`` the file is expected to contain a top-level array of objects

--- a/src/convmerge/normalize/jsonl.py
+++ b/src/convmerge/normalize/jsonl.py
@@ -1,0 +1,215 @@
+"""Load, detect shape of, and normalize JSON / JSONL files."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Literal
+
+JSONLShape = Literal["jsonl", "single_line", "json_array", "invalid", "empty"]
+
+# Bytes scanned from the head of a file to decide its shape without loading everything.
+_HEAD_PEEK_BYTES = 65536
+
+
+def load_jsonl(path: str | Path, *, max_rows: int | None = None) -> list[dict[str, Any]]:
+    """Load a well-formed JSONL file into a list of dicts.
+
+    Lines that are empty are skipped. Any line that fails to parse aborts the
+    load and returns an empty list, mirroring the permissive loader used in the
+    Neura_Data base notebook.
+    """
+    out: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            if max_rows is not None and len(out) >= max_rows:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as e:
+                # Caller gets an empty list; the failing location is still printed
+                # so the user can fix the source file.
+                print(f"[JSONL ERROR] {path} line {i}: {e} :: {line[:80]!r}")
+                return []
+            if isinstance(obj, dict):
+                out.append(obj)
+    return out
+
+
+def iter_json_records(
+    path: str | Path, *, max_rows: int | None = None
+) -> Iterator[dict[str, Any]]:
+    """Iterate dict records from a ``.json`` or ``.jsonl`` file.
+
+    For ``.json`` the file is expected to contain a top-level array of objects
+    (or a single object, which is yielded as one record). For ``.jsonl`` one
+    JSON object per line is expected.
+    """
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".jsonl":
+        yielded = 0
+        with p.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if isinstance(obj, dict):
+                    yield obj
+                    yielded += 1
+                    if max_rows is not None and yielded >= max_rows:
+                        return
+        return
+
+    if suffix == ".json":
+        with p.open(encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                # Fallback: treat it as JSONL (some datasets ship .json that is really JSONL).
+                yield from iter_json_records(p.with_suffix(".jsonl"), max_rows=max_rows)
+                return
+        if isinstance(data, dict):
+            yield data
+            return
+        if isinstance(data, list):
+            for i, item in enumerate(data):
+                if max_rows is not None and i >= max_rows:
+                    return
+                if isinstance(item, dict):
+                    yield item
+        return
+
+    raise ValueError(f"Unsupported file extension for iter_json_records: {p.suffix!r}")
+
+
+def detect_jsonl_shape(path: str | Path) -> JSONLShape:
+    """Classify the layout of a ``.json`` / ``.jsonl`` file without loading it all.
+
+    - ``jsonl``       : multiple non-empty lines, each a JSON object.
+    - ``single_line`` : exactly one line containing one or more JSON objects
+      (common for dumps that forgot to add newlines; e.g. ``{...}{...}``).
+    - ``json_array``  : one line that parses as a JSON array.
+    - ``empty``       : file has no non-empty content.
+    - ``invalid``     : none of the above.
+    """
+    p = Path(path)
+    with p.open("rb") as f:
+        head = f.read(_HEAD_PEEK_BYTES)
+    if not head.strip():
+        return "empty"
+    text = head.decode("utf-8", errors="ignore")
+
+    non_empty_lines = [line for line in text.splitlines() if line.strip()]
+    if len(non_empty_lines) >= 2:
+        return "jsonl"
+
+    first = non_empty_lines[0].strip() if non_empty_lines else ""
+    if not first:
+        return "empty"
+
+    try:
+        parsed = json.loads(first)
+    except json.JSONDecodeError:
+        # Concatenated objects like ``{...}{...}{...}`` are not valid JSON but
+        # can be recovered by splitting on ``}{``.
+        if first.count("}{") > 0:
+            return "single_line"
+        return "invalid"
+
+    if isinstance(parsed, list):
+        return "json_array"
+    if isinstance(parsed, dict):
+        return "single_line"
+    return "invalid"
+
+
+def normalize_to_jsonl(src: str | Path, dst: str | Path) -> int:
+    """Rewrite ``src`` into a well-formed JSONL file at ``dst``.
+
+    Returns the number of records written. Handles:
+
+    - Already-valid JSONL (copies while skipping empty lines).
+    - Top-level JSON arrays (``[ {...}, {...}, ... ]``).
+    - Single-line concatenated objects (``{...}{...}{...}``).
+    """
+    src_p = Path(src)
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    shape = detect_jsonl_shape(src_p)
+    if shape == "empty":
+        dst_p.write_text("", encoding="utf-8")
+        return 0
+
+    if shape == "jsonl":
+        return _rewrite_jsonl(src_p, dst_p)
+    if shape == "json_array":
+        return _rewrite_json_array(src_p, dst_p)
+    if shape == "single_line":
+        return _rewrite_single_line(src_p, dst_p)
+    raise ValueError(f"Cannot normalize {src_p}: shape detected as {shape!r}")
+
+
+def _rewrite_jsonl(src: Path, dst: Path) -> int:
+    n = 0
+    with src.open(encoding="utf-8") as fin, dst.open("w", encoding="utf-8") as fout:
+        for line in fin:
+            line = line.strip()
+            if not line:
+                continue
+            # Validate each line so the output is guaranteed to round-trip.
+            json.loads(line)
+            fout.write(line + "\n")
+            n += 1
+    return n
+
+
+def _rewrite_json_array(src: Path, dst: Path) -> int:
+    with src.open(encoding="utf-8") as fin:
+        data = json.load(fin)
+    if not isinstance(data, list):
+        raise ValueError(f"{src} is not a JSON array")
+    n = 0
+    with dst.open("w", encoding="utf-8") as fout:
+        for obj in data:
+            fout.write(json.dumps(obj, ensure_ascii=False) + "\n")
+            n += 1
+    return n
+
+
+def _rewrite_single_line(src: Path, dst: Path) -> int:
+    text = src.read_text(encoding="utf-8").strip()
+    records = _split_concatenated_objects(text)
+    n = 0
+    with dst.open("w", encoding="utf-8") as fout:
+        for obj in records:
+            fout.write(json.dumps(obj, ensure_ascii=False) + "\n")
+            n += 1
+    return n
+
+
+def _split_concatenated_objects(text: str) -> list[Any]:
+    """Parse ``{...}{...}{...}`` by walking the string with a brace counter.
+
+    Respects strings and escapes so characters inside JSON strings are not
+    counted as braces.
+    """
+    out: list[Any] = []
+    decoder = json.JSONDecoder()
+    i = 0
+    n = len(text)
+    while i < n:
+        while i < n and text[i].isspace():
+            i += 1
+        if i >= n:
+            break
+        obj, end = decoder.raw_decode(text, i)
+        out.append(obj)
+        i = end
+    return out

--- a/src/convmerge/normalize/parquet.py
+++ b/src/convmerge/normalize/parquet.py
@@ -1,0 +1,39 @@
+"""Streaming parquet-to-JSONL conversion.
+
+Requires the optional ``parquet`` extra::
+
+    pip install "convmerge[parquet]"
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def parquet_to_jsonl(src: str | Path, dst: str | Path, *, batch_rows: int = 65536) -> int:
+    """Stream a parquet file into a JSONL file row by row.
+
+    Uses PyArrow's record-batch iterator so the whole table never needs to live
+    in memory. Returns the number of rows written.
+    """
+    try:
+        import pyarrow.parquet as pq
+    except ImportError as e:
+        raise RuntimeError(
+            "pyarrow is required for parquet conversion. "
+            "Install with: pip install 'convmerge[parquet]'"
+        ) from e
+
+    src_p = Path(src)
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    pf = pq.ParquetFile(src_p)
+    n_written = 0
+    with dst_p.open("w", encoding="utf-8") as wf:
+        for batch in pf.iter_batches(batch_size=batch_rows):
+            for row in batch.to_pylist():
+                wf.write(json.dumps(row, ensure_ascii=False, default=str) + "\n")
+                n_written += 1
+    return n_written

--- a/src/convmerge/normalize/schema.py
+++ b/src/convmerge/normalize/schema.py
@@ -1,0 +1,84 @@
+"""Uniform-schema detection and key-frequency counting for JSON/JSONL files."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from convmerge.normalize.jsonl import iter_json_records
+
+
+def is_uniform_schema(
+    records: Iterable[dict[str, Any]] | str | Path,
+    *,
+    max_rows: int | None = None,
+) -> bool:
+    """Check whether every record in ``records`` has the same top-level keys.
+
+    Accepts either an iterable of dicts or a path to a ``.json`` / ``.jsonl``
+    file. Returns ``True`` iff every record is a dict and shares the exact key
+    set of the first dict encountered.
+    """
+    iterator = _as_record_iter(records, max_rows=max_rows)
+    base: set[str] | None = None
+    for item in iterator:
+        if not isinstance(item, dict):
+            return False
+        keys = set(item.keys())
+        if base is None:
+            base = keys
+            continue
+        if keys != base:
+            return False
+    return base is not None
+
+
+def key_frequency(
+    records: Iterable[dict[str, Any]] | str | Path,
+    *,
+    recursive: bool = False,
+    max_rows: int | None = None,
+) -> dict[str, int]:
+    """Count how often each key name appears across records.
+
+    With ``recursive=True``, keys nested inside dict/list values are counted too
+    (useful for discovering fields like ``messages[*].role``).
+    """
+    counts: Counter[str] = Counter()
+    for rec in _as_record_iter(records, max_rows=max_rows):
+        if not isinstance(rec, dict):
+            continue
+        _tally_keys(rec, counts, recursive=recursive)
+    return dict(counts)
+
+
+def _tally_keys(obj: Any, counts: Counter[str], *, recursive: bool) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            counts[k] += 1
+            if recursive:
+                _tally_keys(v, counts, recursive=recursive)
+    elif recursive and isinstance(obj, list):
+        for item in obj:
+            _tally_keys(item, counts, recursive=recursive)
+
+
+def _as_record_iter(
+    records: Iterable[dict[str, Any]] | str | Path,
+    *,
+    max_rows: int | None,
+) -> Iterable[dict[str, Any]]:
+    if isinstance(records, (str, Path)):
+        return iter_json_records(records, max_rows=max_rows)
+    if max_rows is None:
+        return records
+    return _limit(records, max_rows)
+
+
+def _limit(it: Iterable[dict[str, Any]], n: int) -> Iterable[dict[str, Any]]:
+    for i, item in enumerate(it):
+        if i >= n:
+            return
+        yield item

--- a/src/convmerge/normalize/turns.py
+++ b/src/convmerge/normalize/turns.py
@@ -1,0 +1,90 @@
+"""Turn-count analysis and single/multi-turn splitting on messages-style JSONL."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def count_turns(sample: dict[str, Any]) -> int:
+    """Return the number of assistant turns in a messages-style sample."""
+    msgs = sample.get("messages") or []
+    return sum(1 for m in msgs if isinstance(m, dict) and m.get("role") == "assistant")
+
+
+def is_single_turn(sample: dict[str, Any]) -> bool:
+    """True when the sample contains exactly one assistant turn."""
+    return count_turns(sample) == 1
+
+
+def analyze_turn_distribution(path: str | Path) -> dict[str, Any]:
+    """Compute single-turn vs multi-turn counts for a JSONL file.
+
+    Returns a dict with keys ``total``, ``single``, ``multi``, and
+    ``distribution`` (mapping turn-count -> number of samples).
+    """
+    p = Path(path)
+    single = 0
+    multi = 0
+    dist: Counter[int] = Counter()
+    with p.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            sample = json.loads(line)
+            if not isinstance(sample, dict):
+                continue
+            turns = count_turns(sample)
+            dist[turns] += 1
+            if turns == 1:
+                single += 1
+            else:
+                multi += 1
+    return {
+        "total": single + multi,
+        "single": single,
+        "multi": multi,
+        "distribution": dict(sorted(dist.items())),
+    }
+
+
+def split_by_turns(
+    src: str | Path,
+    *,
+    single_out: str | Path,
+    multi_out: str | Path,
+) -> tuple[int, int]:
+    """Split a messages-style JSONL file into single-turn and multi-turn files.
+
+    Returns ``(single_written, multi_written)``.
+    """
+    src_p = Path(src)
+    single_p = Path(single_out)
+    multi_p = Path(multi_out)
+    single_p.parent.mkdir(parents=True, exist_ok=True)
+    multi_p.parent.mkdir(parents=True, exist_ok=True)
+
+    s_count = 0
+    m_count = 0
+    with (
+        src_p.open(encoding="utf-8") as rf,
+        single_p.open("w", encoding="utf-8") as sf,
+        multi_p.open("w", encoding="utf-8") as mf,
+    ):
+        for line in rf:
+            raw = line.strip()
+            if not raw:
+                continue
+            sample = json.loads(raw)
+            if not isinstance(sample, dict):
+                continue
+            if is_single_turn(sample):
+                sf.write(raw + "\n")
+                s_count += 1
+            else:
+                mf.write(raw + "\n")
+                m_count += 1
+    return s_count, m_count

--- a/tests/test_chat_adapter.py
+++ b/tests/test_chat_adapter.py
@@ -1,0 +1,107 @@
+"""Tests for the auto-detecting chat adapter."""
+
+from __future__ import annotations
+
+from convmerge.adapters import ADAPTERS
+from convmerge.adapters.chat import iter_from_chat_line
+
+
+def test_messages_shape() -> None:
+    record = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    }
+    out = list(iter_from_chat_line(record))
+    assert len(out) == 1
+    msgs = out[0].messages
+    assert [m.role for m in msgs] == ["user", "assistant"]
+    assert msgs[0].content == "hi"
+
+
+def test_sharegpt_style_conversations_from_value() -> None:
+    record = {
+        "conversations": [
+            {"from": "human", "value": "Q"},
+            {"from": "gpt", "value": "A"},
+        ]
+    }
+    out = list(iter_from_chat_line(record))
+    assert len(out) == 1
+    assert [m.role for m in out[0].messages] == ["user", "assistant"]
+    assert out[0].messages[1].content == "A"
+
+
+def test_conversation_singular_key() -> None:
+    record = {
+        "conversation": [
+            {"role": "user", "content": "Q"},
+            {"role": "assistant", "content": "A"},
+        ]
+    }
+    out = list(iter_from_chat_line(record))
+    assert len(out) == 1
+
+
+def test_plain_text_becomes_single_assistant_turn() -> None:
+    out = list(iter_from_chat_line({"text": "just some pretraining text"}))
+    assert len(out) == 1
+    assert out[0].messages[0].role == "assistant"
+    assert out[0].messages[0].content.startswith("just some")
+
+
+def test_alpaca_fallback() -> None:
+    out = list(
+        iter_from_chat_line(
+            {"instruction": "Q", "input": "ctx", "output": "A"},
+        )
+    )
+    assert len(out) == 1
+    msgs = out[0].messages
+    assert msgs[-1].role == "assistant"
+    assert msgs[-1].content == "A"
+
+
+def _pairwise_record(winner: str | None = None) -> dict:
+    out: dict = {
+        "conversation_a": [
+            {"role": "user", "content": "Q"},
+            {"role": "assistant", "content": "A1"},
+        ],
+        "conversation_b": [
+            {"role": "user", "content": "Q"},
+            {"role": "assistant", "content": "A2"},
+        ],
+    }
+    if winner is not None:
+        out["winner"] = winner
+    return out
+
+
+def test_pairwise_winner_a() -> None:
+    out = list(iter_from_chat_line(_pairwise_record("model_a")))
+    assert len(out) == 1
+    assert out[0].messages[-1].content == "A1"
+
+
+def test_pairwise_both() -> None:
+    out = list(iter_from_chat_line(_pairwise_record(), pairwise_mode="both"))
+    assert len(out) == 2
+    contents = {ex.messages[-1].content for ex in out}
+    assert contents == {"A1", "A2"}
+
+
+def test_pairwise_tie_emits_nothing() -> None:
+    assert list(iter_from_chat_line(_pairwise_record("tie"))) == []
+
+
+def test_adapter_registered() -> None:
+    assert "chat" in ADAPTERS
+    assert "auto" in ADAPTERS
+
+
+def test_role_map_override() -> None:
+    record = {"messages": [{"role": "foo", "content": "x"}]}
+    out = list(iter_from_chat_line(record, role_map={"foo": "assistant"}))
+    assert out[0].messages[0].role == "assistant"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,81 @@
-from convmerge import __version__
+"""Smoke tests for CLI subcommands (no network, no heavy deps)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from convmerge.cli import main
 
 
-def test_version() -> None:
-    assert __version__ == "0.1.0"
+def test_cli_help_runs(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "convmerge" in out
+    for cmd in ("convert", "normalize", "dedupe", "turns", "fetch"):
+        assert cmd in out
+
+
+def test_cli_normalize_on_json_array(tmp_path: Path) -> None:
+    src = tmp_path / "in.json"
+    src.write_text(json.dumps([{"a": 1}, {"a": 2}]), encoding="utf-8")
+    dst = tmp_path / "out.jsonl"
+    main(["normalize", "--input", str(src), "--output", str(dst)])
+    assert dst.is_file()
+    assert dst.read_text(encoding="utf-8").count("\n") == 2
+
+
+def test_cli_dedupe(tmp_path: Path) -> None:
+    src = tmp_path / "in.jsonl"
+    src.write_text('{"x":1}\n{"x":1}\n{"x":2}\n', encoding="utf-8")
+    dst = tmp_path / "out.jsonl"
+    main(["dedupe", "--input", str(src), "--output", str(dst)])
+    assert dst.read_text(encoding="utf-8").count("\n") == 2
+
+
+def test_cli_turns(tmp_path: Path, capsys) -> None:
+    src = tmp_path / "in.jsonl"
+    sample_single = {
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "a"},
+        ]
+    }
+    sample_multi = {
+        "messages": [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+    }
+    src.write_text(
+        json.dumps(sample_single) + "\n" + json.dumps(sample_multi) + "\n",
+        encoding="utf-8",
+    )
+    single_out = tmp_path / "single.jsonl"
+    multi_out = tmp_path / "multi.jsonl"
+    main(
+        [
+            "turns",
+            "--input",
+            str(src),
+            "--single-out",
+            str(single_out),
+            "--multi-out",
+            str(multi_out),
+        ]
+    )
+    report = json.loads(capsys.readouterr().out)
+    assert report["single"] == 1
+    assert report["multi"] == 1
+    assert single_out.is_file() and multi_out.is_file()
+
+
+def test_cli_fetch_missing_manifest(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        main(["fetch", str(tmp_path / "does_not_exist.yaml")])

--- a/tests/test_fetch_auth.py
+++ b/tests/test_fetch_auth.py
@@ -1,0 +1,39 @@
+"""Tests for token resolution and URL redaction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from convmerge.fetch.auth import TokenSpec, redact_url, resolve_token
+
+
+def test_resolve_token_explicit_wins(monkeypatch, tmp_path: Path) -> None:
+    file_p = tmp_path / "tok"
+    file_p.write_text("FROM_FILE", encoding="utf-8")
+    monkeypatch.setenv("CM_TOK", "FROM_ENV")
+    spec = TokenSpec(env="CM_TOK", file=str(file_p))
+    assert resolve_token(spec, explicit="FROM_CLI") == "FROM_CLI"
+
+
+def test_resolve_token_file_over_env(monkeypatch, tmp_path: Path) -> None:
+    file_p = tmp_path / "tok"
+    file_p.write_text("FROM_FILE", encoding="utf-8")
+    monkeypatch.setenv("CM_TOK", "FROM_ENV")
+    spec = TokenSpec(env="CM_TOK", file=str(file_p))
+    assert resolve_token(spec) == "FROM_FILE"
+
+
+def test_resolve_token_env_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("CM_TOK", "E")
+    assert resolve_token(TokenSpec(env="CM_TOK")) == "E"
+
+
+def test_resolve_token_none_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("CM_TOK", raising=False)
+    assert resolve_token(TokenSpec(env="CM_TOK")) is None
+
+
+def test_redact_url_strips_userinfo() -> None:
+    assert redact_url("https://user:s3cr3t@github.com/org/repo") == "https://github.com/org/repo"
+    assert redact_url("https://github.com/org/repo") == "https://github.com/org/repo"
+    assert redact_url("http://tok@example.com") == "http://example.com"

--- a/tests/test_fetch_git.py
+++ b/tests/test_fetch_git.py
@@ -1,0 +1,85 @@
+"""Tests for the git / git-lfs wrapper (subprocess mocked)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from convmerge.fetch import git as gitmod
+
+
+def test_clone_repo_invokes_git(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check=True):
+        calls.append(list(cmd))
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr(gitmod.shutil, "which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr(gitmod.subprocess, "run", fake_run)
+
+    gitmod.clone_repo("https://github.com/owner/repo", tmp_path / "dst")
+    assert calls == [["git", "clone", "https://github.com/owner/repo", str(tmp_path / "dst")]]
+
+
+def test_clone_repo_injects_token_for_github(monkeypatch, tmp_path: Path) -> None:
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, check=True):
+        captured.append(list(cmd))
+
+    monkeypatch.setattr(gitmod.shutil, "which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr(gitmod.subprocess, "run", fake_run)
+
+    gitmod.clone_repo("https://github.com/owner/repo", tmp_path / "dst", token="TOK")
+    url_arg = captured[0][2]
+    assert "TOK@github.com" in url_arg
+    assert url_arg.startswith("https://user:TOK@github.com/")
+
+
+def test_clone_repo_does_not_inject_token_for_other_hosts(monkeypatch, tmp_path: Path) -> None:
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, check=True):
+        captured.append(list(cmd))
+
+    monkeypatch.setattr(gitmod.shutil, "which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr(gitmod.subprocess, "run", fake_run)
+
+    gitmod.clone_repo("https://gitlab.com/o/r", tmp_path / "dst", token="TOK")
+    assert captured[0][2] == "https://gitlab.com/o/r"
+
+
+def test_clone_repo_lfs_pull(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check=True):
+        calls.append(list(cmd))
+
+    monkeypatch.setattr(gitmod.shutil, "which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr(gitmod.subprocess, "run", fake_run)
+
+    dst = tmp_path / "dst"
+    gitmod.clone_repo("https://github.com/o/r", dst, lfs=True)
+    assert any(cmd[:4] == ["git", "-C", str(dst), "lfs"] for cmd in calls)
+
+
+def test_clone_repo_missing_git(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(gitmod.shutil, "which", lambda name: None)
+    with pytest.raises(gitmod.GitNotFoundError):
+        gitmod.clone_repo("https://github.com/o/r", tmp_path / "d")
+
+
+def test_clone_repo_missing_lfs(monkeypatch, tmp_path: Path) -> None:
+    def which(name: str) -> str | None:
+        return "/usr/bin/git" if name == "git" else None
+
+    monkeypatch.setattr(gitmod.shutil, "which", which)
+    monkeypatch.setattr(gitmod.subprocess, "run", lambda *a, **kw: None)
+    with pytest.raises(gitmod.GitLfsNotFoundError):
+        gitmod.clone_repo("https://github.com/o/r", tmp_path / "d", lfs=True)

--- a/tests/test_fetch_github.py
+++ b/tests/test_fetch_github.py
@@ -1,0 +1,115 @@
+"""Tests for GitHub raw + Trees API fetching (urllib mocked, no network)."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from convmerge.fetch import github as gh
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_parse_repo_url() -> None:
+    assert gh.parse_repo_url("https://github.com/Owner/Repo") == ("Owner", "Repo")
+    assert gh.parse_repo_url("https://github.com/Owner/Repo.git") == ("Owner", "Repo")
+    assert gh.parse_repo_url("https://github.com/Owner/Repo/tree/main") == ("Owner", "Repo")
+
+
+def test_parse_repo_url_invalid() -> None:
+    with pytest.raises(ValueError):
+        gh.parse_repo_url("https://gitlab.com/o/r")
+
+
+def test_download_raw_file_writes_bytes(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        return _FakeResponse(b"hello world")
+
+    monkeypatch.setattr(gh.urllib.request, "urlopen", fake_urlopen)
+
+    dst = tmp_path / "nested" / "out.jsonl"
+    gh.download_raw_file("https://raw.githubusercontent.com/o/r/m/a.jsonl", dst, token="abc")
+    assert dst.read_bytes() == b"hello world"
+    assert captured["url"] == "https://raw.githubusercontent.com/o/r/m/a.jsonl"
+    # Header names are title-cased by urllib.
+    headers = {k.lower(): v for k, v in captured["headers"].items()}  # type: ignore[union-attr]
+    assert headers["authorization"] == "token abc"
+
+
+def test_download_raw_file_no_auth_when_no_token(monkeypatch, tmp_path: Path) -> None:
+    def fake_urlopen(req, timeout=None):
+        headers = {k.lower() for k, _ in req.header_items()}
+        assert "authorization" not in headers
+        return _FakeResponse(b"x")
+
+    monkeypatch.setattr(gh.urllib.request, "urlopen", fake_urlopen)
+    gh.download_raw_file("https://raw.githubusercontent.com/o/r/m/a.jsonl", tmp_path / "a")
+
+
+def test_download_raw_file_http_error(monkeypatch, tmp_path: Path) -> None:
+    def boom(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(gh.urllib.request, "urlopen", boom)
+    with pytest.raises(gh.GitHubFetchError) as exc:
+        gh.download_raw_file("https://raw.githubusercontent.com/o/r/m/a.jsonl", tmp_path / "a")
+    assert "404" in str(exc.value)
+
+
+def test_fetch_repo_tree_files_filters_by_ext(monkeypatch, tmp_path: Path) -> None:
+    tree_response = {
+        "tree": [
+            {"type": "blob", "path": "data/a.jsonl"},
+            {"type": "blob", "path": "data/b.txt"},
+            {"type": "tree", "path": "data"},
+            {"type": "blob", "path": "README.md"},
+            {"type": "blob", "path": "sub/dir/c.jsonl"},
+        ]
+    }
+
+    calls: list[str] = []
+
+    def fake_urlopen(req, timeout=None):
+        url = req.full_url
+        calls.append(url)
+        if url.endswith("/repos/owner/repo"):
+            return _FakeResponse(json.dumps({"default_branch": "main"}).encode())
+        if "/git/trees/" in url:
+            return _FakeResponse(json.dumps(tree_response).encode())
+        return _FakeResponse(b"FILE:" + url.encode())
+
+    monkeypatch.setattr(gh.urllib.request, "urlopen", fake_urlopen)
+
+    downloaded = gh.fetch_repo_tree_files(
+        "https://github.com/owner/repo",
+        tmp_path / "out",
+        ext=(".jsonl",),
+        token="TOK",
+    )
+    names = sorted(p.name for p in downloaded)
+    assert names == ["data_a.jsonl", "sub_dir_c.jsonl"]
+    # Downloaded files exist and contain the mocked body.
+    for p in downloaded:
+        assert p.read_bytes().startswith(b"FILE:")
+    # Tree API was queried with recursive=1.
+    assert any("/git/trees/main?recursive=1" in url for url in calls)

--- a/tests/test_fetch_hf.py
+++ b/tests/test_fetch_hf.py
@@ -1,0 +1,61 @@
+"""Tests for the HuggingFace fetch wrapper (no real downloads)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _install_fake_datasets(monkeypatch, calls: list[dict]) -> None:
+    class _FakeDS:
+        def to_json(self, path: str) -> None:
+            calls.append({"event": "to_json", "path": path})
+            Path(path).write_text("", encoding="utf-8")
+
+    def fake_load_dataset(*args, **kwargs):
+        calls.append({"event": "load_dataset", "args": args, "kwargs": kwargs})
+        return _FakeDS()
+
+    mod = types.SimpleNamespace(load_dataset=fake_load_dataset)
+    monkeypatch.setitem(sys.modules, "datasets", mod)
+
+
+def test_download_hf_dataset_basic(monkeypatch, tmp_path: Path) -> None:
+    calls: list[dict] = []
+    _install_fake_datasets(monkeypatch, calls)
+
+    from convmerge.fetch.hf import download_hf_dataset
+
+    dst = tmp_path / "out.jsonl"
+    out = download_hf_dataset("org/ds", dst, split="train")
+    assert out == dst
+    assert dst.is_file()
+    assert calls[0]["args"] == ("org/ds",)
+    assert calls[0]["kwargs"] == {"split": "train"}
+    assert calls[1]["event"] == "to_json"
+
+
+def test_download_hf_dataset_passes_config_and_token(monkeypatch, tmp_path: Path) -> None:
+    calls: list[dict] = []
+    _install_fake_datasets(monkeypatch, calls)
+
+    from convmerge.fetch.hf import download_hf_dataset
+
+    download_hf_dataset(
+        "org/ds", tmp_path / "out.jsonl", config="sub", split="validation", token="T"
+    )
+    kwargs = calls[0]["kwargs"]
+    assert kwargs["name"] == "sub"
+    assert kwargs["split"] == "validation"
+    assert kwargs["token"] == "T"
+
+
+def test_download_hf_dataset_missing_datasets(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setitem(sys.modules, "datasets", None)
+    from convmerge.fetch.hf import download_hf_dataset
+
+    with pytest.raises(ImportError):
+        download_hf_dataset("org/ds", tmp_path / "out.jsonl")

--- a/tests/test_fetch_manifest.py
+++ b/tests/test_fetch_manifest.py
@@ -1,0 +1,134 @@
+"""Tests for YAML manifest parsing and entry classification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from convmerge.fetch.manifest import (  # noqa: E402
+    DatasetEntry,
+    classify_entry,
+    load_manifest,
+    sanitize_name,
+)
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    p = tmp_path / "m.yaml"
+    p.write_text(dedent(text), encoding="utf-8")
+    return p
+
+
+def test_sanitize_name_strips_bad_chars() -> None:
+    assert sanitize_name("foo/bar:baz") == "foo_bar_baz"
+    assert sanitize_name("   ") == "unnamed"
+    assert sanitize_name("a b\tc") == "a_b_c"
+
+
+def test_load_manifest_basic(tmp_path: Path) -> None:
+    m = load_manifest(
+        _write(
+            tmp_path,
+            """
+            version: 1
+            defaults:
+              output_root: ./raw
+              on_error: continue
+              resume: true
+            auth:
+              hf_token_env: HF_TOKEN
+              github_token_env: GITHUB_TOKEN
+            datasets:
+              - name: ds-a
+                hf: org/dataset-a
+                split: train
+              - name: ds-b
+                url: https://github.com/org/repo
+                ext: [.jsonl]
+            """,
+        )
+    )
+    assert m.version == 1
+    assert m.defaults.output_root == "./raw"
+    assert m.defaults.on_error == "continue"
+    assert m.auth.hf.env == "HF_TOKEN"
+    assert m.auth.github.env == "GITHUB_TOKEN"
+    assert [d.name for d in m.datasets] == ["ds-a", "ds-b"]
+    assert m.datasets[0].hf == "org/dataset-a"
+    assert m.datasets[1].ext == (".jsonl",)
+
+
+def test_load_manifest_rejects_both_hf_and_url(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        load_manifest(
+            _write(
+                tmp_path,
+                """
+                version: 1
+                datasets:
+                  - name: bad
+                    hf: org/ds
+                    url: https://github.com/foo/bar
+                """,
+            )
+        )
+
+
+def test_load_manifest_rejects_neither_hf_nor_url(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        load_manifest(
+            _write(
+                tmp_path,
+                """
+                version: 1
+                datasets:
+                  - name: bad
+                """,
+            )
+        )
+
+
+def test_load_manifest_bad_version(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        load_manifest(
+            _write(
+                tmp_path,
+                """
+                version: 99
+                datasets: []
+                """,
+            )
+        )
+
+
+def test_classify_entry_hf() -> None:
+    assert classify_entry(DatasetEntry(name="x", hf="org/ds")) == "hf"
+
+
+def test_classify_entry_raw_github() -> None:
+    e = DatasetEntry(name="x", url="https://raw.githubusercontent.com/o/r/main/a.jsonl")
+    assert classify_entry(e) == "url_raw"
+
+
+def test_classify_entry_raw_suffix() -> None:
+    e = DatasetEntry(name="x", url="https://example.com/foo/bar.jsonl")
+    assert classify_entry(e) == "url_raw"
+
+
+def test_classify_entry_github_tree_default() -> None:
+    e = DatasetEntry(name="x", url="https://github.com/owner/repo")
+    assert classify_entry(e) == "url_github_tree"
+
+
+def test_classify_entry_github_clone() -> None:
+    e = DatasetEntry(name="x", url="https://github.com/owner/repo", mode="clone")
+    assert classify_entry(e) == "url_github_clone"
+
+
+def test_classify_entry_rejects_unknown_host() -> None:
+    with pytest.raises(ValueError):
+        classify_entry(DatasetEntry(name="x", url="https://gitlab.com/o/r"))

--- a/tests/test_fetch_runner.py
+++ b/tests/test_fetch_runner.py
@@ -1,0 +1,175 @@
+"""End-to-end runner tests (all backends mocked)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from convmerge.fetch import runner  # noqa: E402
+from convmerge.fetch.manifest import (  # noqa: E402
+    AuthConfig,
+    DatasetEntry,
+    Defaults,
+    Manifest,
+    TokenSpec,
+)
+
+
+def _make_manifest(entries: list[DatasetEntry], root: Path) -> Manifest:
+    return Manifest(
+        version=1,
+        auth=AuthConfig(hf=TokenSpec(env="HF_X"), github=TokenSpec(env="GH_X")),
+        defaults=Defaults(output_root=str(root), on_error="continue", resume=True),
+        datasets=tuple(entries),
+    )
+
+
+def test_runner_dispatches_all_backends(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, object]] = []
+
+    def fake_hf(dataset_id, dst, *, config=None, split=None, token=None):
+        calls.append(("hf", {"id": dataset_id, "dst": str(dst), "token": token}))
+        Path(dst).parent.mkdir(parents=True, exist_ok=True)
+        Path(dst).write_text("{}\n", encoding="utf-8")
+        return Path(dst)
+
+    def fake_raw(url, dst, *, token=None):
+        calls.append(("raw", {"url": url, "dst": str(dst), "token": token}))
+        Path(dst).parent.mkdir(parents=True, exist_ok=True)
+        Path(dst).write_text("{}\n", encoding="utf-8")
+        return Path(dst)
+
+    def fake_tree(url, dst, *, ext=(), token=None):
+        calls.append(("tree", {"url": url, "dst": str(dst), "ext": ext, "token": token}))
+        Path(dst).mkdir(parents=True, exist_ok=True)
+        (Path(dst) / "a.jsonl").write_text("{}\n", encoding="utf-8")
+        return [Path(dst) / "a.jsonl"]
+
+    def fake_clone(url, dst, *, token=None, lfs=False):
+        calls.append(("clone", {"url": url, "dst": str(dst), "token": token, "lfs": lfs}))
+        Path(dst).mkdir(parents=True, exist_ok=True)
+        (Path(dst) / "file.bin").write_text("x", encoding="utf-8")
+        return Path(dst)
+
+    import convmerge.fetch.git as gitmod
+    import convmerge.fetch.github as ghmod
+    import convmerge.fetch.hf as hfmod
+
+    monkeypatch.setattr(hfmod, "download_hf_dataset", fake_hf)
+    monkeypatch.setattr(ghmod, "download_raw_file", fake_raw)
+    monkeypatch.setattr(ghmod, "fetch_repo_tree_files", fake_tree)
+    monkeypatch.setattr(gitmod, "clone_repo", fake_clone)
+
+    monkeypatch.setenv("HF_X", "HF_TOKEN_VALUE")
+    monkeypatch.setenv("GH_X", "GH_TOKEN_VALUE")
+
+    entries = [
+        DatasetEntry(name="hf-one", hf="org/a", split="train"),
+        DatasetEntry(
+            name="raw-one",
+            url="https://raw.githubusercontent.com/o/r/m/a.jsonl",
+        ),
+        DatasetEntry(
+            name="tree-one",
+            url="https://github.com/o/r1",
+            ext=(".jsonl",),
+        ),
+        DatasetEntry(
+            name="clone-one",
+            url="https://github.com/o/r2",
+            mode="clone",
+            lfs=True,
+        ),
+    ]
+    manifest = _make_manifest(entries, tmp_path)
+    result = runner.run_manifest(manifest, log=lambda _msg: None)
+
+    assert sorted(result.succeeded) == ["clone-one", "hf-one", "raw-one", "tree-one"]
+    assert result.failed == []
+    kinds = [c[0] for c in calls]
+    assert kinds == ["hf", "raw", "tree", "clone"]
+    # Tokens were resolved from env.
+    assert calls[0][1]["token"] == "HF_TOKEN_VALUE"
+    assert calls[1][1]["token"] == "GH_TOKEN_VALUE"
+    assert calls[2][1]["token"] == "GH_TOKEN_VALUE"
+    assert calls[3][1]["token"] == "GH_TOKEN_VALUE"
+
+
+def test_runner_resume_skips_existing(monkeypatch, tmp_path: Path) -> None:
+    import convmerge.fetch.hf as hfmod
+
+    hits: list[str] = []
+
+    def fake_hf(*a, **kw):
+        hits.append("called")
+        raise AssertionError("should have been skipped")
+
+    monkeypatch.setattr(hfmod, "download_hf_dataset", fake_hf)
+
+    # Pre-populate the expected target so resume should skip it.
+    target = tmp_path / "hf-one.jsonl"
+    target.write_text("{}\n", encoding="utf-8")
+
+    entries = [DatasetEntry(name="hf-one", hf="org/a")]
+    manifest = _make_manifest(entries, tmp_path)
+    result = runner.run_manifest(manifest, log=lambda _msg: None)
+    assert result.skipped == ["hf-one"]
+    assert hits == []
+
+
+def test_runner_continues_on_error(monkeypatch, tmp_path: Path) -> None:
+    import convmerge.fetch.hf as hfmod
+
+    def boom(*a, **kw):
+        raise RuntimeError("download failed")
+
+    monkeypatch.setattr(hfmod, "download_hf_dataset", boom)
+
+    entries = [
+        DatasetEntry(name="ds1", hf="org/a"),
+        DatasetEntry(name="ds2", hf="org/b"),
+    ]
+    manifest = _make_manifest(entries, tmp_path)
+    result = runner.run_manifest(manifest, log=lambda _msg: None)
+    assert [n for n, _ in result.failed] == ["ds1", "ds2"]
+    assert result.succeeded == []
+
+
+def test_runner_on_error_fail_raises(monkeypatch, tmp_path: Path) -> None:
+    import convmerge.fetch.hf as hfmod
+
+    def boom(*a, **kw):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(hfmod, "download_hf_dataset", boom)
+
+    manifest = Manifest(
+        defaults=Defaults(output_root=str(tmp_path), on_error="fail", resume=True),
+        datasets=(DatasetEntry(name="ds1", hf="org/a"),),
+    )
+    with pytest.raises(RuntimeError):
+        runner.run_manifest(manifest, log=lambda _msg: None)
+
+
+def test_runner_only_filter(monkeypatch, tmp_path: Path) -> None:
+    import convmerge.fetch.hf as hfmod
+
+    seen: list[str] = []
+
+    def fake_hf(dataset_id, dst, *, config=None, split=None, token=None):
+        seen.append(dataset_id)
+        Path(dst).write_text("{}\n", encoding="utf-8")
+        return Path(dst)
+
+    monkeypatch.setattr(hfmod, "download_hf_dataset", fake_hf)
+
+    entries = [
+        DatasetEntry(name="keep", hf="org/keep"),
+        DatasetEntry(name="drop", hf="org/drop"),
+    ]
+    manifest = _make_manifest(entries, tmp_path)
+    runner.run_manifest(manifest, only=["keep"], log=lambda _msg: None)
+    assert seen == ["org/keep"]

--- a/tests/test_normalize_convert_turns.py
+++ b/tests/test_normalize_convert_turns.py
@@ -9,9 +9,7 @@ from convmerge.normalize.convert_turns import (
 
 
 def test_single_to_multi_basic() -> None:
-    r = single_turn_to_multi_turn_record(
-        {"instruction": "Q", "input": "ctx", "output": "A"}
-    )
+    r = single_turn_to_multi_turn_record({"instruction": "Q", "input": "ctx", "output": "A"})
     assert r is not None
     assert r["messages"][0]["role"] == "user"
     assert "Q" in r["messages"][0]["content"]

--- a/tests/test_normalize_convert_turns.py
+++ b/tests/test_normalize_convert_turns.py
@@ -1,0 +1,44 @@
+"""Tests for convmerge.normalize.convert_turns."""
+
+from __future__ import annotations
+
+from convmerge.normalize.convert_turns import (
+    multi_turn_to_single_turn_record,
+    single_turn_to_multi_turn_record,
+)
+
+
+def test_single_to_multi_basic() -> None:
+    r = single_turn_to_multi_turn_record(
+        {"instruction": "Q", "input": "ctx", "output": "A"}
+    )
+    assert r is not None
+    assert r["messages"][0]["role"] == "user"
+    assert "Q" in r["messages"][0]["content"]
+    assert "ctx" in r["messages"][0]["content"]
+    assert r["messages"][1] == {"role": "assistant", "content": "A"}
+
+
+def test_single_to_multi_requires_output() -> None:
+    assert single_turn_to_multi_turn_record({"instruction": "Q"}) is None
+
+
+def test_multi_to_single_flattens_users() -> None:
+    sample = {
+        "messages": [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+    }
+    r = multi_turn_to_single_turn_record(sample)
+    assert r is not None
+    assert r["instruction"] == "u1\nu2"
+    assert r["output"] == "a2"
+    assert r["input"] == ""
+
+
+def test_multi_to_single_returns_none_without_assistant() -> None:
+    sample = {"messages": [{"role": "user", "content": "u1"}]}
+    assert multi_turn_to_single_turn_record(sample) is None

--- a/tests/test_normalize_dedup.py
+++ b/tests/test_normalize_dedup.py
@@ -1,0 +1,55 @@
+"""Tests for convmerge.normalize.dedup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from convmerge.normalize.dedup import deduplicate_jsonl
+
+
+def _write(path: Path, rows: list[dict]) -> Path:
+    with path.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    return path
+
+
+def test_dedup_full_record(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "src.jsonl",
+        [{"a": 1}, {"a": 1}, {"a": 2}, {"a": 1, "b": 2}],
+    )
+    dst = tmp_path / "out.jsonl"
+    total, kept = deduplicate_jsonl(src, dst)
+    assert (total, kept) == (4, 3)
+
+
+def test_dedup_by_keys(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path / "src.jsonl",
+        [
+            {"id": 1, "q": "same"},
+            {"id": 2, "q": "same"},
+            {"id": 3, "q": "different"},
+        ],
+    )
+    dst = tmp_path / "out.jsonl"
+    total, kept = deduplicate_jsonl(src, dst, keys=["q"])
+    assert (total, kept) == (3, 2)
+
+
+def test_dedup_sha256(tmp_path: Path) -> None:
+    src = _write(tmp_path / "src.jsonl", [{"a": 1}, {"a": 1}])
+    dst = tmp_path / "out.jsonl"
+    total, kept = deduplicate_jsonl(src, dst, algorithm="sha256")
+    assert (total, kept) == (2, 1)
+
+
+def test_dedup_unknown_algorithm(tmp_path: Path) -> None:
+    src = _write(tmp_path / "src.jsonl", [{"a": 1}])
+    dst = tmp_path / "out.jsonl"
+    with pytest.raises(ValueError):
+        deduplicate_jsonl(src, dst, algorithm="blake2zz")

--- a/tests/test_normalize_jsonl.py
+++ b/tests/test_normalize_jsonl.py
@@ -1,0 +1,83 @@
+"""Tests for convmerge.normalize.jsonl."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from convmerge.normalize.jsonl import (
+    detect_jsonl_shape,
+    iter_json_records,
+    load_jsonl,
+    normalize_to_jsonl,
+)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_detect_shape_jsonl(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.jsonl", '{"a":1}\n{"a":2}\n')
+    assert detect_jsonl_shape(p) == "jsonl"
+
+
+def test_detect_shape_json_array(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.json", '[{"a":1},{"a":2}]')
+    assert detect_jsonl_shape(p) == "json_array"
+
+
+def test_detect_shape_single_line_concatenated(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.jsonl", '{"a":1}{"a":2}{"a":3}')
+    assert detect_jsonl_shape(p) == "single_line"
+
+
+def test_detect_shape_single_object(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.jsonl", '{"a":1}')
+    assert detect_jsonl_shape(p) == "single_line"
+
+
+def test_detect_shape_empty(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.jsonl", "")
+    assert detect_jsonl_shape(p) == "empty"
+
+
+def test_normalize_json_array(tmp_path: Path) -> None:
+    src = _write(tmp_path / "a.json", '[{"x":1},{"x":2}]')
+    dst = tmp_path / "out.jsonl"
+    n = normalize_to_jsonl(src, dst)
+    assert n == 2
+    lines = dst.read_text(encoding="utf-8").strip().splitlines()
+    assert [json.loads(line) for line in lines] == [{"x": 1}, {"x": 2}]
+
+
+def test_normalize_single_line_concatenated(tmp_path: Path) -> None:
+    src = _write(tmp_path / "a.jsonl", '{"x":1}{"x":2}{"x":3}')
+    dst = tmp_path / "out.jsonl"
+    n = normalize_to_jsonl(src, dst)
+    assert n == 3
+    assert dst.read_text(encoding="utf-8").count("\n") == 3
+
+
+def test_normalize_valid_jsonl_passthrough(tmp_path: Path) -> None:
+    src = _write(tmp_path / "a.jsonl", '{"x":1}\n\n{"x":2}\n')
+    dst = tmp_path / "out.jsonl"
+    n = normalize_to_jsonl(src, dst)
+    assert n == 2
+
+
+def test_load_jsonl_skips_blank_lines(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.jsonl", '{"a":1}\n\n{"a":2}\n')
+    rows = load_jsonl(p)
+    assert rows == [{"a": 1}, {"a": 2}]
+
+
+def test_iter_json_records_handles_json_single_object(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.json", '{"only":"one"}')
+    assert list(iter_json_records(p)) == [{"only": "one"}]
+
+
+def test_iter_json_records_max_rows(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.jsonl", '{"x":1}\n{"x":2}\n{"x":3}\n')
+    assert list(iter_json_records(p, max_rows=2)) == [{"x": 1}, {"x": 2}]

--- a/tests/test_normalize_parquet.py
+++ b/tests/test_normalize_parquet.py
@@ -1,0 +1,29 @@
+"""Tests for convmerge.normalize.parquet (requires pyarrow)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+
+from convmerge.normalize.parquet import parquet_to_jsonl  # noqa: E402
+
+
+def test_parquet_roundtrip(tmp_path: Path) -> None:
+    table = pa.table({"id": [1, 2, 3], "text": ["a", "b", "c"]})
+    src = tmp_path / "in.parquet"
+    pq.write_table(table, src)
+
+    dst = tmp_path / "out.jsonl"
+    n = parquet_to_jsonl(src, dst, batch_rows=2)
+    assert n == 3
+    rows = [json.loads(line) for line in dst.read_text(encoding="utf-8").splitlines()]
+    assert rows == [
+        {"id": 1, "text": "a"},
+        {"id": 2, "text": "b"},
+        {"id": 3, "text": "c"},
+    ]

--- a/tests/test_normalize_schema.py
+++ b/tests/test_normalize_schema.py
@@ -1,0 +1,44 @@
+"""Tests for convmerge.normalize.schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from convmerge.normalize.schema import is_uniform_schema, key_frequency
+
+
+def test_is_uniform_schema_true() -> None:
+    records = [{"a": 1, "b": 2}, {"a": 10, "b": 20}]
+    assert is_uniform_schema(records) is True
+
+
+def test_is_uniform_schema_false_on_different_keys() -> None:
+    records = [{"a": 1, "b": 2}, {"a": 10, "c": 20}]
+    assert is_uniform_schema(records) is False
+
+
+def test_is_uniform_schema_false_on_non_dict() -> None:
+    records = [{"a": 1}, "not a dict"]
+    assert is_uniform_schema(records) is False  # type: ignore[list-item]
+
+
+def test_key_frequency_counts_top_level() -> None:
+    records = [{"a": 1, "b": 2}, {"a": 10}, {"b": 5, "c": 99}]
+    counts = key_frequency(records)
+    assert counts == {"a": 2, "b": 2, "c": 1}
+
+
+def test_key_frequency_recursive() -> None:
+    records = [
+        {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}
+    ]
+    counts = key_frequency(records, recursive=True)
+    assert counts["messages"] == 1
+    assert counts["role"] == 2
+    assert counts["content"] == 2
+
+
+def test_is_uniform_schema_from_jsonl_file(tmp_path: Path) -> None:
+    p = tmp_path / "a.jsonl"
+    p.write_text('{"x":1,"y":2}\n{"x":3,"y":4}\n', encoding="utf-8")
+    assert is_uniform_schema(p) is True

--- a/tests/test_normalize_turns.py
+++ b/tests/test_normalize_turns.py
@@ -1,0 +1,54 @@
+"""Tests for convmerge.normalize.turns."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from convmerge.normalize.turns import (
+    analyze_turn_distribution,
+    count_turns,
+    is_single_turn,
+    split_by_turns,
+)
+
+
+def _make_sample(turns: int) -> dict:
+    messages = []
+    for _ in range(turns):
+        messages.append({"role": "user", "content": "q"})
+        messages.append({"role": "assistant", "content": "a"})
+    return {"messages": messages}
+
+
+def test_count_turns_and_single() -> None:
+    assert count_turns(_make_sample(1)) == 1
+    assert count_turns(_make_sample(3)) == 3
+    assert is_single_turn(_make_sample(1)) is True
+    assert is_single_turn(_make_sample(2)) is False
+
+
+def test_analyze_turn_distribution(tmp_path: Path) -> None:
+    p = tmp_path / "a.jsonl"
+    with p.open("w", encoding="utf-8") as f:
+        for t in (1, 1, 2, 3, 3, 3):
+            f.write(json.dumps(_make_sample(t)) + "\n")
+    report = analyze_turn_distribution(p)
+    assert report["total"] == 6
+    assert report["single"] == 2
+    assert report["multi"] == 4
+    assert report["distribution"] == {1: 2, 2: 1, 3: 3}
+
+
+def test_split_by_turns(tmp_path: Path) -> None:
+    src = tmp_path / "src.jsonl"
+    with src.open("w", encoding="utf-8") as f:
+        for t in (1, 2, 1, 3):
+            f.write(json.dumps(_make_sample(t)) + "\n")
+
+    single_out = tmp_path / "single.jsonl"
+    multi_out = tmp_path / "multi.jsonl"
+    s, m = split_by_turns(src, single_out=single_out, multi_out=multi_out)
+    assert (s, m) == (2, 2)
+    assert sum(1 for _ in single_out.open(encoding="utf-8")) == 2
+    assert sum(1 for _ in multi_out.open(encoding="utf-8")) == 2


### PR DESCRIPTION
## Summary

Bumps the package to **v0.2.0** and adds the first batch of open-sourced
pipeline features:

- **`convmerge fetch`** — YAML-manifest driven downloader for HuggingFace
  (thin wrapper over `datasets.load_dataset`) and GitHub (raw URL / Trees API
  with `ext` filter / `git clone` + optional `git lfs pull`). Token
  resolution order is CLI flag -> file -> env var; URLs are redacted in logs.
  Single-URL / `hf://` shortcut mode included.
- **`convmerge normalize`** — streaming parquet / JSON array / concatenated
  `{...}{...}` -> clean JSONL, directory-batch mode.
- **`convmerge dedupe`** — streaming MD5/SHA256 dedup with optional key
  projection.
- **`convmerge turns`** — turn distribution report + single/multi split.
- **`convmerge.adapters.chat`** (alias `auto`) — auto-detecting adapter for
  `messages` / `conversation(s)` / `text` / pairwise preference rows with a
  configurable role map and alpaca-style fallback.
- **Packaging** — new optional extras `[fetch]` (pyyaml), `[fetch-hf]`
  (+datasets), `[fetch-all]`, `[parquet]` (pyarrow). Core runtime keeps
  **zero** required third-party dependencies.
- **Publish workflow** — `.github/workflows/publish.yml` now authenticates
  via the `PYPI_API_TOKEN` GitHub Actions secret instead of OIDC.
- **Docs** — 4-case README, new `docs/fetch.md`, `docs/format.md` updated
  with the chat adapter + normalize utilities, `CHANGELOG.md` entry.

Out of scope for this PR (deferred): `convmerge serve` classification server,
`presets/` examples.

## Test plan

- [x] `ruff check src tests` — all clean.
- [x] `pytest -q` — 87 passed locally (normalize, fetch, chat adapter, CLI
      smoke tests; parquet tests are auto-skipped when `pyarrow` missing).
- [x] `hatch build` — produces 0.2.0 sdist + wheel, wheel contains
      `fetch/`, `normalize/`, `adapters/chat.py`, and entry points.
- [ ] CI (Ruff + pytest matrix) passes on PR.
- [ ] After merge, tag `v0.2.0` -> `publish.yml` uploads to PyPI using the
      `PYPI_API_TOKEN` secret (account-scoped for the first upload, to be
      rotated to a project-scoped token afterwards).

## Release checklist (post-merge)

1. Merge this PR into `main`.
2. `git tag v0.2.0 && git push origin v0.2.0`.
3. Watch the `Publish` workflow; confirm the package appears on
   https://pypi.org/project/convmerge/.
4. Rotate `PYPI_API_TOKEN` to a project-scoped token and revoke the original
   account-scoped token.

Made with [Cursor](https://cursor.com)