### PR TITLE
docs: clarify product scope and adapter heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # convmerge
 
-Fetch, normalize, and convert heterogeneous chat / instruct datasets into a
-**single LLM training format** (JSONL).
+`convmerge` is a **data-preparation library** for supervised fine-tuning (SFT)
+datasets. It fetches, normalizes, and merges heterogeneous chat / instruct
+sources into a single newline-delimited JSON Lines layout that training code
+can consume directly.
+
+It is intentionally scoped to the **pre-training-loop** step: no model
+loading, no inference, no labeling, no training orchestration. See
+[Out of scope](#out-of-scope) below.
 
 **Repository:** [github.com/snowmuffin/convmerge](https://github.com/snowmuffin/convmerge)  
-**Status:** pre-1.0; APIs and CLI may change between minor versions.
+**Status:** pre-1.0; APIs and CLI may change between minor versions until 1.0.
 
 ## Install
 
@@ -28,6 +34,12 @@ pip install -e ".[dev,fetch-all,parquet]"
 ## The four use cases
 
 ### 1. `fetch` — pull raw data from HF + GitHub via a YAML manifest
+
+> HuggingFace entries delegate to `datasets.load_dataset(...).to_json(...)`,
+> i.e. the output is a **JSONL dump** of the selected split. GitHub entries
+> support a single raw URL, recursive Trees API fetch with an extension
+> filter, or `git clone` (with optional `git lfs pull`). `fetch` is a
+> reproducible downloader, not a mirror of HuggingFace's Arrow cache.
 
 ```yaml
 # manifest.yaml
@@ -77,6 +89,13 @@ convmerge convert -i ./jsonl/mixed.jsonl -o ./train/mixed.messages.jsonl \
 Adapters: `alpaca`, `sharegpt`, `chat` (alias `auto`).  
 Emitters: `messages`, `alpaca`.
 
+> `chat` / `auto` is a **heuristic** adapter: it inspects the keys of each
+> input record (`messages`, `conversation(s)`, `text`, `conversation_a`/`_b`,
+> `instruction`/`input`/`output`, …) and routes to the right branch with a
+> configurable role map. For unusual schemas, pin an explicit adapter
+> (`alpaca`, `sharegpt`) or override keys programmatically — see
+> [docs/format.md](docs/format.md).
+
 ### 4. `dedupe` / `turns` — final cleanup + train/eval split hook
 
 ```bash
@@ -88,6 +107,30 @@ convmerge turns  -i ./train/mixed.dedup.jsonl \
 
 See [docs/format.md](docs/format.md) for adapter / emitter schemas and
 [docs/fetch.md](docs/fetch.md) for manifest details.
+
+## Out of scope
+
+To keep the package lean and dependency-free at its core, `convmerge` does
+**not** include — and has no plans to include — the following:
+
+- **Model loading / inference / training.** No PyTorch, Transformers, vLLM,
+  or similar runtime is imported by the core or any shipped extra.
+- **Automatic labeling or classification of samples** (e.g. topic tagging,
+  quality scoring, safety classification). These are left to upstream tools
+  or private pipelines.
+- **RLHF / DPO / preference-dataset construction** beyond passing through
+  existing pairwise rows via the `chat` adapter's `pairwise_mode`.
+- **Training-job orchestration** (SkyPilot, RunPod, Modal, K8s operators).
+- **Prompt templating / chat-template rendering** for specific model
+  families. Output JSONL uses the standard `messages` / `alpaca` shapes;
+  downstream trainers apply their own template.
+- **Tokenizer-aware length filtering, packing, or curriculum scheduling.**
+  Those live in the training stack, not here.
+- **Scraping HTML pages or running browser automation.** Structured JSON /
+  JSONL / Parquet inputs only.
+
+If any of these are important to your workflow, wire `convmerge` in as one
+step of a larger pipeline rather than expecting it to grow into those areas.
 
 ## Development
 
@@ -103,13 +146,18 @@ pytest -q
 
 Releases run from [`.github/workflows/publish.yml`](.github/workflows/publish.yml)
 on pushing a `v*` tag. Publishing authenticates via the **`PYPI_API_TOKEN`**
-GitHub Actions secret (a PyPI API token scoped to the `convmerge` project).
+GitHub Actions secret.
 
-1. Create an API token on [pypi.org](https://pypi.org/manage/account/token/)
-   scoped to `convmerge`.
+1. Create an API token on [pypi.org](https://pypi.org/manage/account/token/).
+   - If the project already exists on PyPI, scope the token to the
+     `convmerge` project (principle of least privilege).
+   - For the very first upload (project not yet registered), PyPI does not
+     allow project-scoped tokens — use **Entire account** scope for the
+     first release, then rotate to a project-scoped token afterwards and
+     revoke the original.
 2. In the GitHub repo, *Settings → Secrets and variables → Actions → New
    repository secret*, add `PYPI_API_TOKEN` with the token value.
-3. Tag and push: `git tag v0.2.0 && git push origin v0.2.0`.
+3. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`.
 
 ## Changelog
 

--- a/docs/fetch.md
+++ b/docs/fetch.md
@@ -3,8 +3,20 @@
 The `convmerge fetch` subcommand reads a YAML manifest listing HuggingFace
 datasets and/or GitHub URLs and downloads each one into a per-source directory
 under a shared output root. It is intentionally a thin layer: HuggingFace
-entries delegate to `datasets.load_dataset`, and GitHub entries use either the
-stdlib HTTP client, the Trees API, or `git clone` depending on the entry.
+entries delegate to `datasets.load_dataset(...).to_json(...)`, and GitHub
+entries use either the stdlib HTTP client, the Trees API, or `git clone`
+depending on the entry.
+
+**What it is not:**
+
+- Not a parallel downloader, CDN, or mirror. It calls HuggingFace /
+  GitHub directly, one entry at a time, and honours their rate limits.
+- Not a replacement for HuggingFace's Arrow cache. Output is a **JSONL
+  dump** of the chosen split — convenient for downstream text pipelines,
+  but less efficient than `datasets.load_dataset` for repeated random
+  access.
+- Not a dataset discovery tool. You still name every source explicitly in
+  the manifest.
 
 ```bash
 pip install "convmerge[fetch-all]"   # YAML + HuggingFace datasets

--- a/docs/format.md
+++ b/docs/format.md
@@ -42,7 +42,14 @@ Emits one example per consecutive user→assistant pair.
 
 ### `chat` (alias: `auto`)
 
-Auto-detecting adapter for mixed / unknown chat schemas. Tries, in order:
+A **heuristic** auto-detecting adapter for mixed or unknown chat schemas.
+It does not read a schema descriptor — it inspects which keys are present on
+each record and routes to the matching branch. Unusual or ambiguous shapes
+may not be detected correctly; in that case either pin an explicit adapter
+(`alpaca`, `sharegpt`) or call `iter_from_chat_line` directly with overridden
+key lists (see below).
+
+Tries, in order:
 
 1. Pairwise preference rows (`conversation_a` / `conversation_b` with optional `winner`).
    - Default `pairwise_mode="winner"` emits only the winning branch; ties/unknown are skipped.
@@ -76,9 +83,23 @@ subcommands handle the pre-adapter cleanup step:
 
 ## Non-goals (current)
 
-- **HTML / raw web pages**: full-site scraping and boilerplate removal are out of scope for core; a future optional extra may wrap libraries like `trafilatura`.
-- **Binary / proprietary formats**: not supported unless added as explicit adapters.
-- **Guaranteed lossless round-trip** across all formats: not guaranteed; formats are views over the internal message list.
+- **Model loading, inference, or training.** `convmerge` never imports
+  PyTorch / Transformers / vLLM / etc. See the README's "Out of scope"
+  section.
+- **Automatic labeling or classification of samples.** No topic, quality,
+  or safety classifier ships with this package.
+- **Prompt-template rendering for specific model families.** Output JSONL
+  uses the standard `messages` / `alpaca` shapes; downstream trainers apply
+  their own chat template.
+- **Tokenizer-aware length filtering or packing.** These live in the
+  training stack.
+- **HTML / raw web pages.** Full-site scraping and boilerplate removal are
+  out of scope for core; a future optional extra may wrap libraries like
+  `trafilatura`.
+- **Binary / proprietary formats.** Not supported unless added as explicit
+  adapters.
+- **Guaranteed lossless round-trip** across all formats: not guaranteed;
+  formats are views over the internal message list.
 
 ## Adding an adapter
 


### PR DESCRIPTION
## Summary

Docs-only PR that closes the small expectation gaps noticed after v0.2.0
shipped. No code or dependency changes.

- **README: Out of scope.** New section explicitly lists model inference,
  training, automatic labeling, RLHF/DPO dataset construction, training-
  job orchestration, chat-template rendering, tokenizer-aware filtering,
  and HTML scraping as non-goals. The top paragraph is reworded to call
  ``convmerge`` a *data-preparation library* rather than a broad
  "LLM training" tool.
- **README: fetch / auto callouts.** Add short notes that HuggingFace
  fetch is a ``datasets.load_dataset(...).to_json(...)`` JSONL dump (not
  an Arrow cache mirror), and that ``chat`` / ``auto`` is a
  key-heuristic adapter — unusual schemas should pin an explicit adapter
  or override the key lists.
- **README: PyPI release.** Correct the token-scoping guidance: PyPI does
  not allow project-scoped tokens for the very first upload of a new
  project, so the first release uses an account-scoped token and the
  secret is rotated to a project-scoped token afterwards.
- **docs/format.md.** Expand the ``chat`` adapter description with the
  same heuristic caveat, and extend "Non-goals" with the inference /
  labeling / template / tokenizer items so the docs stay consistent
  with the README.
- **docs/fetch.md.** Add a "What it is not" block covering parallelism,
  HuggingFace Arrow cache, and dataset discovery.

## Test plan

- [x] ``ruff format --check src tests`` — clean.
- [x] ``ruff check src tests`` — clean.
- [x] ``pytest -q`` — 87 passed (no code changes; sanity only).
- [ ] CI green on the PR.

Made with [Cursor](https://cursor.com)