### PR TITLE
chore: community infrastructure for contributor onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
     id: version
     attributes:
       label: convmerge version
-      placeholder: e.g. 0.1.0
+      placeholder: e.g. 0.2.0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,8 @@
 blank_issues_enabled: true
-contact_links: []
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/snowmuffin/convmerge/blob/main/CONTRIBUTING.md
+    about: Dev setup, adapter walkthrough, and what the project does / doesn't accept.
+  - name: Documentation
+    url: https://github.com/snowmuffin/convmerge#readme
+    about: README and docs for the CLI, adapters, emitters, and fetch manifest.

--- a/.github/ISSUE_TEMPLATE/fetch_issue.yml
+++ b/.github/ISSUE_TEMPLATE/fetch_issue.yml
@@ -1,0 +1,61 @@
+name: Fetch (YAML manifest) issue
+description: Problems with `convmerge fetch` or a specific HuggingFace / GitHub source
+labels: ["bug", "fetch"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template if `convmerge fetch` fails or produces unexpected
+        output for a specific source. If the issue is with the general
+        format of output JSONL, use the bug report template instead.
+  - type: input
+    id: version
+    attributes:
+      label: convmerge version
+      description: Output of `convmerge --version` (or the installed package version).
+      placeholder: e.g. 0.2.0
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install extras
+      description: Which extras did you install? (select all that apply)
+      multiple: true
+      options:
+        - "[fetch] (GitHub only)"
+        - "[fetch-hf] (HuggingFace)"
+        - "[fetch-all]"
+        - "[parquet]"
+        - core only
+    validations:
+      required: true
+  - type: textarea
+    id: manifest
+    attributes:
+      label: Manifest snippet or CLI shortcut
+      description: Paste the relevant entry (or the `convmerge fetch hf://...` shortcut you ran). Redact tokens.
+      render: yaml
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Full command
+      placeholder: convmerge fetch manifest.yaml -o ./raw
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Log output
+      description: Paste the stderr / stdout of the failing run. Tokens in URLs are redacted automatically — double check before posting.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/new_adapter.yml
+++ b/.github/ISSUE_TEMPLATE/new_adapter.yml
@@ -1,0 +1,59 @@
+name: New adapter / emitter
+description: Request support for a public chat / instruct schema
+labels: ["enhancement", "adapter"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to request a new **adapter** (input format) or
+        **emitter** (output format). Good requests include a concrete
+        reference schema and a small redacted sample.
+  - type: input
+    id: format_name
+    attributes:
+      label: Format name
+      description: The short name you would like for this adapter / emitter.
+      placeholder: e.g. "dolly", "openassistant", "chatml-record"
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Adapter or emitter?
+      options:
+        - Adapter (reads records into TrainingExample)
+        - Emitter (writes records from TrainingExample)
+        - Both
+    validations:
+      required: true
+  - type: input
+    id: reference
+    attributes:
+      label: Reference / public dataset using this schema
+      description: Link to a HuggingFace dataset, GitHub repo, or spec.
+      placeholder: https://huggingface.co/datasets/...
+    validations:
+      required: true
+  - type: textarea
+    id: input_sample
+    attributes:
+      label: Minimal input sample (redacted)
+      description: 2–3 representative JSON records, one per line.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: expected_output
+    attributes:
+      label: Expected output line(s)
+      description: Show what the corresponding `messages` / `alpaca` / custom emitter output should look like.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Edge cases or notes
+      description: Multi-turn? Optional fields? Non-ASCII role names? Anything else reviewers should know.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,22 @@
 ## Summary
 
-<!-- What does this PR change? -->
+<!--
+What does this PR change and why? Keep it to a few sentences.
+If this PR introduces a new adapter / emitter / fetch backend, link the
+reference schema or dataset in the body.
+-->
 
 ## Checklist
 
-- [ ] `ruff check src tests` and `ruff format src tests` pass
-- [ ] `pytest` passes
-- [ ] Docs updated if adapters or formats changed (`docs/format.md`, `README.md`)
+- [ ] `ruff check src tests` and `ruff format --check src tests` pass
+- [ ] `pytest -q` passes
+- [ ] Tests added or updated for behaviour changes
+- [ ] Docs updated if adapters / emitters / CLI changed (`README.md`,
+      `docs/format.md`, `docs/fetch.md`)
+- [ ] `CHANGELOG.md` entry added under `## [Unreleased]`
+- [ ] Change fits the project scope (see README "Out of scope" and
+      `CONTRIBUTING.md` "What we want / don't want")
 
 ## Related issue
 
-<!-- Link e.g. Closes #123 -->
+<!-- e.g. "Closes #123" or "Refs #45". -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `CODE_OF_CONDUCT.md` based on Contributor Covenant 2.1.
+- `examples/` directory with READMEs and ready-to-run `fetch` manifests
+  for Alpaca, ShareGPT, and mixed HF + GitHub sources.
+- New issue templates: `new_adapter.yml` (adapter / emitter request) and
+  `fetch_issue.yml` (fetch manifest problems). Existing config now links
+  to the contributing guide and docs.
+- `py.typed` marker in the distributed wheel, so downstream projects
+  pick up inline type hints via PEP 561.
+
+### Changed
+
+- Expanded `CONTRIBUTING.md`: scope expectations (what is / isn't
+  accepted), review SLA, end-to-end walkthrough for adding a new adapter,
+  clearer install / check steps with the `[fetch-all,parquet]` extras.
+- Richer `pyproject.toml` metadata: more `keywords` and `classifiers`
+  (topic, audience, typed), additional `project.urls` entries for
+  `Changelog` and `Documentation`, and `Development Status` bumped from
+  pre-alpha to alpha.
+- README: added PyPI / Python / CI / downloads / CoC badges, linked the
+  Code of Conduct, and pointed to `good first issue` for contributors.
+
 ## [0.2.0] - 2026-04-20
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers by opening a private report through GitHub's [Report content / abuse](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam) flow on this repository, or by contacting the repository owner [@snowmuffin](https://github.com/snowmuffin) directly. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,39 @@
 # Contributing to convmerge
 
-Upstream: [github.com/snowmuffin/convmerge](https://github.com/snowmuffin/convmerge) — fork it, open a PR from a feature branch.
+Thanks for your interest in improving `convmerge`. This project is small and
+focused on **one thing**: turning heterogeneous chat / instruct datasets into
+clean JSONL for supervised fine-tuning. Contributions that keep it sharp in
+that role are very welcome.
+
+Upstream: [github.com/snowmuffin/convmerge](https://github.com/snowmuffin/convmerge)
+— fork it and open a PR from a feature branch.
+
+## What we want / don't want
+
+**Good fits for a PR (no issue required):**
+
+- New **adapter** for a public chat / instruct schema with a clear reference
+  (ShareGPT variants, OpenOrca, Dolly, OpenAssistant, Firefly, WizardLM, …).
+- New **emitter** that reshapes the internal message list into another
+  standard JSONL layout (e.g. ChatML-like raw record).
+- New **fetch** backend for a public dataset host that can be implemented
+  with stdlib `urllib` or a thin optional dependency (GitLab, Zenodo,
+  Kaggle, …), behind an extras marker.
+- Docs / examples / recipes for real public datasets.
+- Bug fixes with a failing-then-passing test.
+- Performance improvements with a benchmark / rationale.
+
+**Please open an issue first for:**
+
+- New runtime dependency in the core package.
+- Changes to public API shapes (`TrainingExample`, `ChatMessage`, CLI flag
+  names).
+- New CLI subcommand or removal of an existing one.
+- Re-introducing anything listed in the
+  [Out of scope](README.md#out-of-scope) section of the README.
+
+Out-of-scope PRs are closed quickly — not because the idea is bad, but
+because that functionality belongs in a different layer of your pipeline.
 
 ## Setup
 
@@ -8,38 +41,111 @@ Upstream: [github.com/snowmuffin/convmerge](https://github.com/snowmuffin/convme
 git clone https://github.com/<your-username>/convmerge.git
 cd convmerge
 python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
 python -m pip install -U pip
-pip install -e ".[dev]"
+pip install -e ".[dev,fetch-all,parquet]"
 ```
 
-(Add your fork URL as `origin` if you cloned via SSH or a different host.)
+The `[dev,fetch-all,parquet]` extras install everything needed to run the
+full test suite, including the optional `pyarrow` / `datasets` paths.
 
 ## Checks
 
-Run before opening a PR:
+Run these locally before opening a PR — CI runs the same three commands on
+Python 3.10, 3.11, and 3.12:
 
 ```bash
 ruff check src tests
-ruff format src tests
-pytest
+ruff format --check src tests
+pytest -q
 ```
 
-CI runs the same commands on Python 3.10–3.12.
+Autofix style issues with:
+
+```bash
+ruff check --fix src tests
+ruff format src tests
+```
+
+## Code conventions
+
+- **All code comments, docstrings, CLI help strings, and error messages are
+  in English.** Non-English strings inside test fixtures (e.g. Korean sample
+  text) are fine when the test is specifically exercising multi-language
+  handling.
+- Follow the existing 100-character line length (`tool.ruff.line-length`).
+- Keep the **core package dependency-free**. New runtime deps must go
+  behind a named extras marker in `pyproject.toml`.
+- Prefer small, composable functions. Public entry points live in
+  `src/convmerge/__init__.py`; keep them stable.
+- Don't add comments that only narrate what the code does (`# loop over
+  lines`, `# return result`). Comments should explain intent or non-obvious
+  trade-offs.
+
+## Adding a new adapter (walkthrough)
+
+Adapters convert one input record shape into a stream of `TrainingExample`.
+A minimal adapter is ~30 lines.
+
+1. Create `src/convmerge/adapters/<name>.py` exporting
+   `iter_from_<name>_line(record: dict) -> Iterator[TrainingExample]`.
+   Look at `alpaca.py` or `sharegpt.py` for the shape.
+2. Register the adapter in `src/convmerge/adapters/__init__.py`:
+
+   ```python
+   from .your_adapter import iter_from_<name>_line
+   ADAPTERS["<name>"] = iter_from_<name>_line
+   ```
+
+3. Add a fixture under `tests/fixtures/<name>.jsonl` with 3–5 realistic
+   lines (redact anything sensitive).
+4. Add tests in `tests/test_adapters.py` (or a new
+   `tests/test_<name>_adapter.py`) that cover happy path + at least one
+   edge case (empty content, missing optional fields, multi-turn).
+5. Document the adapter in `docs/format.md` under the "Adapters" section.
+6. Add a one-line entry to `CHANGELOG.md` under `## [Unreleased]`.
+
+Emitters follow the same pattern under `src/convmerge/emitters/`.
 
 ## Pull requests
 
-- Keep changes focused (one feature or fix per PR when possible).
-- Add or update tests for behavior changes.
-- Update [docs/format.md](docs/format.md) if you add adapters or output formats.
+- Keep changes **focused** — one feature or fix per PR when possible.
+- Add or update **tests** for any behaviour change.
+- Update **docs** if you touch public surface (`README.md`,
+  `docs/format.md`, `docs/fetch.md`).
+- Fill out the PR template checklist. It's short on purpose.
+- PRs with a red CI badge usually won't get reviewed. Fix lint / format /
+  tests first.
+
+### Review expectations
+
+Maintainers aim to leave a first response within **3 working days**. If a
+week goes by with no reply, it is fine to ping the PR with a short comment
+— we may have missed the notification.
 
 ## Issues
 
-Use the templates under `.github/ISSUE_TEMPLATE/`. For a **new source format**, include:
+Use one of the templates under `.github/ISSUE_TEMPLATE/`:
 
-- A **minimal** redacted JSONL sample (input).
-- Expected output line(s) after conversion.
+- **Bug report** — incorrect conversion, crash, or unexpected output.
+- **New adapter / emitter** — a public chat / instruct schema that is not
+  yet supported. Include a minimal redacted sample and the expected
+  output.
+- **Fetch issue** — problems with the YAML manifest or a specific
+  HuggingFace / GitHub source.
+- **Feature request** — anything else.
 
-## GitHub labels
+Blank issues are also enabled, but templates make triage an order of
+magnitude faster.
 
-The repo uses labels such as `good first issue`, `bug`, `enhancement`, and `adapter` (new or changed source adapter). Pick one when filing an issue.
+## Labels
+
+The repo uses labels such as `good first issue`, `help wanted`, `bug`,
+`enhancement`, `adapter`, `emitter`, `fetch`, and `docs`. Pick one when
+filing an issue; maintainers will relabel as needed.
+
+## Code of Conduct
+
+Participation in this project is governed by the
+[Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you are
+expected to uphold it.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # convmerge
 
+[![PyPI](https://img.shields.io/pypi/v/convmerge.svg)](https://pypi.org/project/convmerge/)
+[![Python versions](https://img.shields.io/pypi/pyversions/convmerge.svg)](https://pypi.org/project/convmerge/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![CI](https://github.com/snowmuffin/convmerge/actions/workflows/ci.yml/badge.svg)](https://github.com/snowmuffin/convmerge/actions/workflows/ci.yml)
+[![PyPI downloads](https://img.shields.io/pypi/dm/convmerge.svg)](https://pypi.org/project/convmerge/)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+
 `convmerge` is a **data-preparation library** for supervised fine-tuning (SFT)
 datasets. It fetches, normalizes, and merges heterogeneous chat / instruct
 sources into a single newline-delimited JSON Lines layout that training code
@@ -134,13 +141,25 @@ step of a larger pipeline rather than expecting it to grow into those areas.
 
 ## Development
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). CI runs Ruff + pytest on Python
-3.10 – 3.12.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide — setup, local
+checks, code conventions, and a walkthrough for adding a new adapter /
+emitter. CI runs Ruff + pytest on Python 3.10 – 3.12.
 
 ```bash
+pip install -e ".[dev,fetch-all,parquet]"
 ruff check src tests
+ruff format --check src tests
 pytest -q
 ```
+
+Participation in this project is governed by the
+[Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+
+Good first PRs: new adapters / emitters for public dataset schemas, new
+fetch backends (GitLab / Zenodo / Kaggle), recipe examples under
+[`examples/`](examples/), and docs improvements. Browse the
+[`good first issue`](https://github.com/snowmuffin/convmerge/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+label for concrete starting points.
 
 ## PyPI release (maintainers)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,83 @@
+# Examples
+
+End-to-end recipes that exercise the full `convmerge` pipeline against
+**public** datasets. Each recipe is small, copy-pasteable, and assumes only
+the installation from the top-level [README](../README.md):
+
+```bash
+pip install "convmerge[fetch-all,parquet]"
+```
+
+> These recipes download data from the public internet. Respect each
+> source's license. `convmerge` does not rehost any dataset.
+
+## Directory layout
+
+- `manifests/` — ready-to-run `convmerge fetch` YAML manifests for various
+  public sources. Safe defaults (`resume: true`, tokens read from env).
+- Per-recipe READMEs below document the full `fetch → normalize → convert
+  → dedupe → turns` sequence for a given dataset family.
+
+## Recipes
+
+### Alpaca-style instruction data (HuggingFace)
+
+Pull [`tatsu-lab/alpaca`](https://huggingface.co/datasets/tatsu-lab/alpaca)
+and emit a clean `messages` JSONL.
+
+```bash
+convmerge fetch examples/manifests/alpaca_hf.yaml -o ./raw
+convmerge normalize -i ./raw/alpaca/train.jsonl -o ./jsonl/alpaca.jsonl
+convmerge convert   -i ./jsonl/alpaca.jsonl    -o ./train/alpaca.messages.jsonl \
+  --from alpaca --format messages
+convmerge dedupe    -i ./train/alpaca.messages.jsonl \
+                    -o ./train/alpaca.messages.dedup.jsonl
+```
+
+### ShareGPT-style multi-turn (HuggingFace)
+
+Pull
+[`anon8231489123/ShareGPT_Vicuna_unfiltered`](https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered)
+(or any ShareGPT mirror of your choice) and split single-turn vs multi-turn.
+
+```bash
+convmerge fetch examples/manifests/sharegpt_hf.yaml -o ./raw
+convmerge normalize -i ./raw/sharegpt/train.jsonl -o ./jsonl/sharegpt.jsonl
+convmerge convert   -i ./jsonl/sharegpt.jsonl    -o ./train/sharegpt.messages.jsonl \
+  --from sharegpt --format messages
+convmerge turns     -i ./train/sharegpt.messages.jsonl \
+  --single-out ./train/sharegpt.single.jsonl \
+  --multi-out  ./train/sharegpt.multi.jsonl
+```
+
+### Mixed sources, auto-detect (HuggingFace + GitHub)
+
+Combine a HuggingFace dataset with raw JSONL files hosted on GitHub, then
+let the heuristic `chat` / `auto` adapter pick the right branch per record.
+
+```bash
+export HF_TOKEN=...     # only needed for gated datasets
+export GITHUB_TOKEN=... # only needed for private / rate-limited repos
+convmerge fetch examples/manifests/mixed_sources.yaml -o ./raw
+convmerge normalize -i ./raw -o ./jsonl
+# One conversion pass per file — use your shell of choice:
+for f in ./jsonl/**/*.jsonl; do
+  out="./train/$(basename "$f" .jsonl).messages.jsonl"
+  convmerge convert -i "$f" -o "$out" --from auto --format messages
+done
+convmerge dedupe -i ./train/*.messages.jsonl -o ./train/combined.messages.dedup.jsonl
+```
+
+## Contributing a recipe
+
+Recipes are a great first contribution. A good recipe:
+
+- Uses a **public** dataset with a clear license.
+- Is self-contained (one manifest + one shell snippet).
+- States the approximate **download size** and **record count** at the
+  top of the README section so readers know what to expect.
+- Does **not** commit the downloaded data — only the manifest and
+  walkthrough.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the general contribution
+process.

--- a/examples/manifests/alpaca_hf.yaml
+++ b/examples/manifests/alpaca_hf.yaml
@@ -1,0 +1,18 @@
+# Minimal HuggingFace-only manifest for the Alpaca instruction dataset.
+# See https://huggingface.co/datasets/tatsu-lab/alpaca for the source.
+#
+# Run:
+#   convmerge fetch examples/manifests/alpaca_hf.yaml -o ./raw
+version: 1
+
+defaults:
+  output_root: ./raw
+  resume: true
+
+auth:
+  hf_token_env: HF_TOKEN
+
+datasets:
+  - name: alpaca
+    hf: tatsu-lab/alpaca
+    split: train

--- a/examples/manifests/mixed_sources.yaml
+++ b/examples/manifests/mixed_sources.yaml
@@ -1,0 +1,43 @@
+# Mixed-source manifest: a HuggingFace dataset plus GitHub-hosted JSONL
+# files. Demonstrates every GitHub mode supported by `convmerge fetch`:
+#
+#   - `url: https://.../raw/.../file.jsonl`
+#       Single raw-file download over HTTPS.
+#   - `url: https://github.com/ORG/REPO` + `ext: [.jsonl]`
+#       Recursive fetch via the GitHub Trees API, filtered by extension.
+#   - `mode: clone`
+#       `git clone` (+ `git lfs pull` if `lfs: true`) for large repos or
+#       binary assets.
+#
+# Replace the placeholder org/repo values with sources you actually use.
+version: 1
+
+defaults:
+  output_root: ./raw
+  resume: true
+
+auth:
+  hf_token_env: HF_TOKEN
+  github_token_env: GITHUB_TOKEN
+
+datasets:
+  # HuggingFace — any public SFT dataset works here.
+  - name: alpaca
+    hf: tatsu-lab/alpaca
+    split: train
+
+  # GitHub: single raw file.
+  - name: extra-train
+    url: https://raw.githubusercontent.com/ORG/REPO/main/data/train.jsonl
+
+  # GitHub: recursive tree fetch, *.jsonl only.
+  - name: repo-jsonl
+    url: https://github.com/ORG/REPO
+    ext:
+      - ".jsonl"
+
+  # GitHub: full clone (useful for repos with LFS or mixed file types).
+  - name: big-lfs-repo
+    url: https://github.com/ORG/BIG-LFS-REPO
+    mode: clone
+    lfs: true

--- a/examples/manifests/sharegpt_hf.yaml
+++ b/examples/manifests/sharegpt_hf.yaml
@@ -1,0 +1,16 @@
+# HuggingFace-only manifest for a ShareGPT-style dataset.
+# Swap the `hf:` line for the mirror you prefer; any dataset with a
+# `conversations: [{from, value}, ...]` column will work.
+version: 1
+
+defaults:
+  output_root: ./raw
+  resume: true
+
+auth:
+  hf_token_env: HF_TOKEN
+
+datasets:
+  - name: sharegpt
+    hf: anon8231489123/ShareGPT_Vicuna_unfiltered
+    split: train

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,36 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [{ name = "convmerge contributors" }]
-keywords = ["llm", "sft", "jsonl", "chat", "dataset"]
+keywords = [
+  "llm",
+  "sft",
+  "fine-tuning",
+  "dataset",
+  "data-preparation",
+  "jsonl",
+  "parquet",
+  "chat",
+  "instruction-tuning",
+  "alpaca",
+  "sharegpt",
+  "huggingface-datasets",
+]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
+  "Environment :: Console",
   "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Text Processing :: Linguistic",
+  "Typing :: Typed",
 ]
 
 dependencies = []
@@ -41,6 +62,8 @@ convmerge = "convmerge.cli:main"
 Homepage = "https://github.com/snowmuffin/convmerge"
 Repository = "https://github.com/snowmuffin/convmerge"
 Issues = "https://github.com/snowmuffin/convmerge/issues"
+Changelog = "https://github.com/snowmuffin/convmerge/blob/main/CHANGELOG.md"
+Documentation = "https://github.com/snowmuffin/convmerge#readme"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/convmerge"]


### PR DESCRIPTION
## Summary

Pure-docs / metadata PR that makes it materially easier for first-time
contributors to land a PR. No runtime code change; core dependency
tree is unchanged.

### Added

- `CODE_OF_CONDUCT.md` based on Contributor Covenant 2.1, with a
  GitHub-native reporting path.
- `examples/` with a top-level README and three ready-to-run `fetch`
  manifests covering Alpaca (HF), ShareGPT (HF), and mixed HF + GitHub
  sources (raw URL, Trees API, clone + LFS).
- Two new issue templates: `new_adapter.yml` for adapter / emitter
  requests (reference schema + sample + expected output) and
  `fetch_issue.yml` for manifest / source-specific bugs.
- `src/convmerge/py.typed` so PEP 561 consumers pick up inline type
  hints. Verified to ship inside the built wheel.

### Changed

- `CONTRIBUTING.md`: explicit "what we want / don't want" section tied
  to the README's Out-of-scope block, a review SLA (3 working days),
  end-to-end adapter walkthrough, and updated install with
  `[dev,fetch-all,parquet]` extras. Documents the English-only comment
  rule and links the CoC.
- `pyproject.toml`: richer `keywords` (including `alpaca`, `sharegpt`,
  `instruction-tuning`) and `classifiers` (AI / Text Processing /
  Typing :: Typed / Intended Audience :: Science/Research), new
  `project.urls` entries for `Changelog` and `Documentation`, and
  `Development Status` bumped from Pre-Alpha (2) to Alpha (3).
- `README.md`: PyPI / Python / License / CI / downloads / CoC badges,
  pointer to `CODE_OF_CONDUCT.md`, and a "good first PRs" block linking
  the `good first issue` label.
- `.github/ISSUE_TEMPLATE/config.yml` now surfaces the contributing
  guide and docs as contact links instead of an empty list.
- `.github/pull_request_template.md` extends the checklist with tests /
  CHANGELOG / scope items so reviewers and authors align earlier.
- `CHANGELOG.md`: added an `Unreleased` section documenting the above.

## Test plan

- [x] ``ruff format --check src tests`` — clean.
- [x] ``ruff check src tests`` — clean.
- [x] ``pytest -q`` — 87 passed (no behaviour change).
- [x] ``python -m build --wheel`` succeeds; ``py.typed`` is present
      inside the wheel and ``METADATA`` contains all new keywords,
      classifiers, and URLs.
- [ ] CI green on the PR.

## Follow-ups (out of this PR)

- Configure GitHub repo Topics (e.g. ``llm``, ``sft``, ``jsonl``,
  ``fine-tuning``, ``huggingface-datasets``) for Explore discoverability.
- Seed 5–8 concrete ``good first issue`` tickets (new adapters, new
  emitters, new fetch backends, recipe expansions).