### PR TITLE
chore(0.2.1): abstract third-party references + release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1] - 2026-04-20
 
 ### Added
 
 - `CODE_OF_CONDUCT.md` based on Contributor Covenant 2.1.
-- `examples/` directory with READMEs and ready-to-run `fetch` manifests
-  for Alpaca, ShareGPT, and mixed HF + GitHub sources.
+- `examples/` directory with a README and ready-to-run `fetch` manifest
+  skeletons for the Alpaca-style, ShareGPT-style, and mixed HF + GitHub
+  patterns. Manifests use `<HF_ORG>/<DATASET>` and `ORG/REPO`
+  placeholders rather than pinning specific third-party datasets.
 - New issue templates: `new_adapter.yml` (adapter / emitter request) and
-  `fetch_issue.yml` (fetch manifest problems). Existing config now links
-  to the contributing guide and docs.
+  `fetch_issue.yml` (fetch manifest problems). Issue config now links to
+  the contributing guide and docs.
 - `py.typed` marker in the distributed wheel, so downstream projects
   pick up inline type hints via PEP 561.
 
 ### Changed
 
 - Expanded `CONTRIBUTING.md`: scope expectations (what is / isn't
-  accepted), review SLA, end-to-end walkthrough for adding a new adapter,
-  clearer install / check steps with the `[fetch-all,parquet]` extras.
+  accepted), review SLA, end-to-end walkthrough for adding a new
+  adapter, and updated install with the `[dev,fetch-all,parquet]`
+  extras. "Good fits" examples are now described by pattern rather than
+  by naming specific third-party projects.
 - Richer `pyproject.toml` metadata: more `keywords` and `classifiers`
   (topic, audience, typed), additional `project.urls` entries for
   `Changelog` and `Documentation`, and `Development Status` bumped from
   pre-alpha to alpha.
-- README: added PyPI / Python / CI / downloads / CoC badges, linked the
-  Code of Conduct, and pointed to `good first issue` for contributors.
+- `README.md`: added PyPI / Python / CI / downloads / CoC badges, linked
+  the Code of Conduct, and pointed to `good first issue` for
+  contributors.
+
+[0.2.1]: https://pypi.org/project/convmerge/0.2.1/
 
 ## [0.2.0] - 2026-04-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,15 @@ Upstream: [github.com/snowmuffin/convmerge](https://github.com/snowmuffin/convme
 
 **Good fits for a PR (no issue required):**
 
-- New **adapter** for a public chat / instruct schema with a clear reference
-  (ShareGPT variants, OpenOrca, Dolly, OpenAssistant, Firefly, WizardLM, …).
+- New **adapter** for a documented public chat / instruct record schema,
+  with a minimal redacted sample and the expected output line.
 - New **emitter** that reshapes the internal message list into another
-  standard JSONL layout (e.g. ChatML-like raw record).
-- New **fetch** backend for a public dataset host that can be implemented
-  with stdlib `urllib` or a thin optional dependency (GitLab, Zenodo,
-  Kaggle, …), behind an extras marker.
-- Docs / examples / recipes for real public datasets.
+  standard JSONL layout.
+- New **fetch** backend for an additional dataset host that can be
+  implemented with stdlib `urllib` or a thin optional dependency, behind
+  an extras marker.
+- Docs and recipe skeletons that illustrate a pattern (placeholders are
+  preferred over pinning specific third-party datasets / repos).
 - Bug fixes with a failing-then-passing test.
 - Performance improvements with a benchmark / rationale.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,31 +1,40 @@
 # Examples
 
-End-to-end recipes that exercise the full `convmerge` pipeline against
-**public** datasets. Each recipe is small, copy-pasteable, and assumes only
-the installation from the top-level [README](../README.md):
+End-to-end recipe skeletons that exercise the full `convmerge` pipeline.
+Each recipe is small, copy-pasteable, and assumes only the installation
+from the top-level [README](../README.md):
 
 ```bash
 pip install "convmerge[fetch-all,parquet]"
 ```
 
-> These recipes download data from the public internet. Respect each
-> source's license. `convmerge` does not rehost any dataset.
+The manifests intentionally use `<HF_ORG>/<DATASET>` and `ORG/REPO`
+**placeholders** rather than pinning any specific public dataset or
+repository. `convmerge` does not endorse or commit to supporting any
+particular third-party source — plug in whichever dataset your project
+actually uses.
+
+> You are responsible for the license of any data you download. Respect
+> each source's terms. `convmerge` does not rehost any dataset.
 
 ## Directory layout
 
-- `manifests/` — ready-to-run `convmerge fetch` YAML manifests for various
-  public sources. Safe defaults (`resume: true`, tokens read from env).
-- Per-recipe READMEs below document the full `fetch → normalize → convert
-  → dedupe → turns` sequence for a given dataset family.
+- `manifests/` — ready-to-run `convmerge fetch` YAML manifests for the
+  common source patterns. Safe defaults (`resume: true`, tokens read
+  from env).
+- This README walks through the full
+  `fetch → normalize → convert → dedupe → turns` sequence for each
+  manifest shape.
 
 ## Recipes
 
 ### Alpaca-style instruction data (HuggingFace)
 
-Pull [`tatsu-lab/alpaca`](https://huggingface.co/datasets/tatsu-lab/alpaca)
-and emit a clean `messages` JSONL.
+Any HuggingFace dataset with `instruction` / `input` / `output` columns
+works with the built-in `alpaca` adapter.
 
 ```bash
+# Edit examples/manifests/alpaca_hf.yaml and set `hf:` to your dataset.
 convmerge fetch examples/manifests/alpaca_hf.yaml -o ./raw
 convmerge normalize -i ./raw/alpaca/train.jsonl -o ./jsonl/alpaca.jsonl
 convmerge convert   -i ./jsonl/alpaca.jsonl    -o ./train/alpaca.messages.jsonl \
@@ -36,11 +45,12 @@ convmerge dedupe    -i ./train/alpaca.messages.jsonl \
 
 ### ShareGPT-style multi-turn (HuggingFace)
 
-Pull
-[`anon8231489123/ShareGPT_Vicuna_unfiltered`](https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered)
-(or any ShareGPT mirror of your choice) and split single-turn vs multi-turn.
+Any HuggingFace dataset whose rows look like
+`{"conversations": [{"from": ..., "value": ...}, ...]}` works with the
+built-in `sharegpt` adapter.
 
 ```bash
+# Edit examples/manifests/sharegpt_hf.yaml and set `hf:` to your dataset.
 convmerge fetch examples/manifests/sharegpt_hf.yaml -o ./raw
 convmerge normalize -i ./raw/sharegpt/train.jsonl -o ./jsonl/sharegpt.jsonl
 convmerge convert   -i ./jsonl/sharegpt.jsonl    -o ./train/sharegpt.messages.jsonl \
@@ -52,15 +62,15 @@ convmerge turns     -i ./train/sharegpt.messages.jsonl \
 
 ### Mixed sources, auto-detect (HuggingFace + GitHub)
 
-Combine a HuggingFace dataset with raw JSONL files hosted on GitHub, then
-let the heuristic `chat` / `auto` adapter pick the right branch per record.
+Combine a HuggingFace dataset with raw JSONL files hosted on GitHub,
+then let the heuristic `chat` / `auto` adapter pick the right branch
+per record.
 
 ```bash
 export HF_TOKEN=...     # only needed for gated datasets
 export GITHUB_TOKEN=... # only needed for private / rate-limited repos
 convmerge fetch examples/manifests/mixed_sources.yaml -o ./raw
 convmerge normalize -i ./raw -o ./jsonl
-# One conversion pass per file — use your shell of choice:
 for f in ./jsonl/**/*.jsonl; do
   out="./train/$(basename "$f" .jsonl).messages.jsonl"
   convmerge convert -i "$f" -o "$out" --from auto --format messages
@@ -70,12 +80,15 @@ convmerge dedupe -i ./train/*.messages.jsonl -o ./train/combined.messages.dedup.
 
 ## Contributing a recipe
 
-Recipes are a great first contribution. A good recipe:
+Recipes are a great documentation contribution. A good recipe:
 
-- Uses a **public** dataset with a clear license.
+- Illustrates a **pattern** (e.g. "alpaca-style on HuggingFace",
+  "a HF dataset plus raw JSONL on GitHub") rather than committing the
+  project to supporting a specific third-party dataset.
+- Keeps dataset / repository identifiers as placeholders
+  (`<HF_ORG>/<DATASET>`, `ORG/REPO`) unless a concrete name is
+  strictly necessary to demonstrate the pattern.
 - Is self-contained (one manifest + one shell snippet).
-- States the approximate **download size** and **record count** at the
-  top of the README section so readers know what to expect.
 - Does **not** commit the downloaded data — only the manifest and
   walkthrough.
 

--- a/examples/manifests/alpaca_hf.yaml
+++ b/examples/manifests/alpaca_hf.yaml
@@ -1,5 +1,6 @@
-# Minimal HuggingFace-only manifest for the Alpaca instruction dataset.
-# See https://huggingface.co/datasets/tatsu-lab/alpaca for the source.
+# Minimal HuggingFace-only manifest for any Alpaca-style instruction
+# dataset. Replace <HF_ORG>/<DATASET> with a dataset that exposes the
+# ``instruction`` / ``input`` / ``output`` columns.
 #
 # Run:
 #   convmerge fetch examples/manifests/alpaca_hf.yaml -o ./raw
@@ -14,5 +15,5 @@ auth:
 
 datasets:
   - name: alpaca
-    hf: tatsu-lab/alpaca
+    hf: <HF_ORG>/<DATASET>
     split: train

--- a/examples/manifests/mixed_sources.yaml
+++ b/examples/manifests/mixed_sources.yaml
@@ -9,7 +9,8 @@
 #       `git clone` (+ `git lfs pull` if `lfs: true`) for large repos or
 #       binary assets.
 #
-# Replace the placeholder org/repo values with sources you actually use.
+# Replace the placeholder ORG / REPO / HF_ORG / DATASET values with the
+# sources you actually use.
 version: 1
 
 defaults:
@@ -22,8 +23,8 @@ auth:
 
 datasets:
   # HuggingFace — any public SFT dataset works here.
-  - name: alpaca
-    hf: tatsu-lab/alpaca
+  - name: hf-sft
+    hf: <HF_ORG>/<DATASET>
     split: train
 
   # GitHub: single raw file.

--- a/examples/manifests/sharegpt_hf.yaml
+++ b/examples/manifests/sharegpt_hf.yaml
@@ -1,6 +1,6 @@
-# HuggingFace-only manifest for a ShareGPT-style dataset.
-# Swap the `hf:` line for the mirror you prefer; any dataset with a
-# `conversations: [{from, value}, ...]` column will work.
+# HuggingFace-only manifest for any ShareGPT-style dataset. Any HF
+# dataset with a ``conversations: [{from, value}, ...]`` column works;
+# replace <HF_ORG>/<DATASET> with the one you want to fetch.
 version: 1
 
 defaults:
@@ -12,5 +12,5 @@ auth:
 
 datasets:
   - name: sharegpt
-    hf: anon8231489123/ShareGPT_Vicuna_unfiltered
+    hf: <HF_ORG>/<DATASET>
     split: train

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "convmerge"
-version = "0.2.0"
+version = "0.2.1"
 description = "Fetch, normalize, and convert heterogeneous chat/instruct datasets into a single LLM training format"
 readme = "README.md"
 license = "MIT"

--- a/src/convmerge/__init__.py
+++ b/src/convmerge/__init__.py
@@ -1,3 +1,3 @@
 """convmerge — merge heterogeneous sources into a single LLM training format."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary

Align the in-tree docs with the policy established when the seeded
issues that named specific third-party datasets / platforms were
closed: `convmerge` illustrates **patterns**, not commitments to any
particular upstream source. Bumps to ``0.2.1`` so the community-infra
work from PR #3 (CoC, examples, ``py.typed``, richer metadata, README
badges) lands on PyPI together with this cleanup.

### Changed

- ``examples/manifests/*.yaml`` now use ``<HF_ORG>/<DATASET>``
  placeholders instead of pinning specific HuggingFace datasets.
  GitHub URLs continue to use ``ORG/REPO`` placeholders as before.
- ``examples/README.md`` drops links to specific public datasets;
  the recipes describe shapes (*Alpaca-style*, *ShareGPT-style*) that
  map to the built-in adapters, with an explicit note that
  placeholders are preferred over concrete names.
- ``CONTRIBUTING.md`` "Good fits" list no longer enumerates specific
  third-party projects; requests are described by pattern.
- Version bumped to ``0.2.1`` in ``pyproject.toml`` and
  ``src/convmerge/__init__.py``.
- ``CHANGELOG.md``: move the previous ``[Unreleased]`` block under
  ``[0.2.1] - 2026-04-20`` and extend the summary to cover this
  cleanup.

## Test plan

- [x] ``ruff format --check src tests`` — clean.
- [x] ``ruff check src tests`` — clean.
- [x] ``pytest -q`` — 87 passed.
- [x] ``python -m build`` produces ``convmerge-0.2.1.tar.gz`` and
      ``convmerge-0.2.1-py3-none-any.whl``.
- [x] ``twine check dist/*`` — PASSED on both artefacts.
- [ ] CI green on the PR.

## Release

After merge, push the ``v0.2.1`` tag to trigger ``publish.yml`` and
cut a GitHub Release.