### PR TITLE
feat(0.3.0): pipeline, reshape, resume/sample/merge/split primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-21
+
+### Added
+
+- **Directory-level normalize primitives** in `convmerge.normalize`:
+  `normalize_dir`, `prune_by_suffix`, `head_preview`, `head_preview_dir`,
+  `scan_shapes`. These hoist the directory-walking logic that previously
+  lived only in the `convmerge normalize` CLI into module-level APIs so
+  notebooks and scripts can reuse them.
+- **Turn filtering**: `convmerge.normalize.filter_by_min_turns(src, dst,
+  min_turns=...)` — stream a JSONL file while dropping rows whose assistant
+  turn count is below a threshold.
+- **New submodules** under `convmerge.normalize`:
+  - `merge.py` — `merge_jsonl(sources, dst)` and
+    `collect_jsonl_tree(source_dirs, dst)` for concatenating files and
+    whole trees with optional JSON validation.
+  - `split.py` — `train_test_split(src, out_dir, train_ratio=..., seed=...,
+    max_samples=...)`. Pure-Python implementation, no numpy dependency.
+  - `sample.py` — `sample_random` (in-memory) and `reservoir_sample`
+    (streaming, memory-bounded) random samplers.
+  - `resume.py` — `count_lines`, `truncate_to_n_lines`, and
+    `trim_corrupt_tail` for append-only JSONL pipelines that need to
+    resume after a crash.
+  - `reshape.py` — directory-level schema unification:
+    `unify_messages_dir`, `unify_message_entries`, `unify_alpaca_dir`,
+    plus row-level helpers `parse_tagged_text` and `classify_row_shape`.
+    In-place rewrites are supported via a temp-directory swap so a crashed
+    run cannot leave partially overwritten files.
+- **Alpaca remap helper**: `convmerge.adapters.alpaca.remap_to_alpaca` is
+  now public (previously `_remap_for_alpaca` in the chat adapter). Use it
+  to pull an `{instruction, input, output}` triple out of a messy
+  single-turn row with configurable key-priority lists.
+- **`convert_dir`**: `convmerge.convert.convert_dir(src_dir, dst_dir,
+  adapter_name=..., output_format=...)` — a thin wrapper that runs
+  `convert_file` over every JSONL under a directory tree while preserving
+  the relative-path layout.
+- **End-to-end pipeline**: `convmerge.pipeline.build_sft_jsonl(raw_dir,
+  out_dir, ...)` runs normalize → reshape → convert → merge → dedupe →
+  filter → split in a single call and returns a `BuildResult` with every
+  intermediate path plus row counts. Intentionally local-filesystem-only:
+  no HuggingFace Hub upload, no labeling, no model inference.
+- **New CLI subcommands**: `convmerge merge`, `convmerge split`,
+  `convmerge sample`, `convmerge build`.
+
+### Changed
+
+- `convmerge.normalize.__init__` re-exports the new primitives so most
+  workflows can import from `convmerge.normalize` directly.
+- `convmerge.adapters.__init__` now exports `remap_to_alpaca` alongside
+  the existing adapter functions.
+
+### Notes on scope
+
+- No new required dependencies were added. `train_test_split` uses the
+  standard-library `random` module; numpy is **not** a dependency of
+  core or of the `pipeline` module.
+- The library's "Out of scope" contract is unchanged — the new modules
+  do not add model loading, inference, training, classification /
+  labeling, tokenizer-aware filtering, or remote-service orchestration.
+
+[0.3.0]: https://pypi.org/project/convmerge/0.3.0/
+
 ## [0.2.1] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,6 +115,60 @@ convmerge turns  -i ./train/mixed.dedup.jsonl \
 See [docs/format.md](docs/format.md) for adapter / emitter schemas and
 [docs/fetch.md](docs/fetch.md) for manifest details.
 
+### 5. `merge` / `split` / `sample` — assemble and shard a final JSONL
+
+```bash
+convmerge merge  -i ./dir_a ./dir_b -o ./final/all.jsonl
+convmerge split  -i ./final/all.jsonl -o ./final --train-ratio 0.98 --seed 42
+convmerge sample -i ./final/all.jsonl -o ./final/peek.jsonl -k 100
+```
+
+- `merge` concatenates arbitrary JSONL files and whole directory trees.
+- `split` does a deterministic, pure-Python train/test split (no numpy).
+- `sample` picks `k` random rows (or streams via `--reservoir` for files
+  that don't fit in memory).
+
+### 6. `build` — end-to-end SFT dataset prep
+
+```bash
+convmerge build --raw ./raw --out ./out --train-ratio 0.98 --min-turns 1
+```
+
+Runs the default pipeline `normalize → reshape → convert → merge → dedupe
+→ filter → split` in a single call and writes `out/final/train.jsonl` and
+`out/final/test.jsonl`. Intermediate trees (`jsonl/`, `multi_turn/`,
+`single_turn/`, `final/`) are laid out under `--out` for inspection.
+From Python, the same pipeline is available as
+`convmerge.pipeline.build_sft_jsonl(...)`, which returns a `BuildResult`
+with every intermediate path plus per-stage row counts.
+
+### Directory-level primitives (library API)
+
+The CLI subcommands above are thin wrappers around module-level helpers
+that are designed to be imported from notebooks and scripts:
+
+```python
+from convmerge.normalize import (
+    normalize_dir, prune_by_suffix, scan_shapes, head_preview_dir,
+    filter_by_min_turns,
+    merge_jsonl, collect_jsonl_tree,
+    train_test_split,
+    sample_random, reservoir_sample,
+    count_lines, truncate_to_n_lines, trim_corrupt_tail,
+    unify_messages_dir, unify_message_entries, unify_alpaca_dir,
+    parse_tagged_text, classify_row_shape,
+)
+from convmerge.convert import convert_dir, convert_file
+from convmerge.adapters.alpaca import remap_to_alpaca
+```
+
+The `unify_*_dir` helpers walk a tree of JSONL files, rewrite each file
+into a uniform schema (messages / alpaca), and preserve relative paths.
+They support in-place rewrites via a temp-directory swap, so a crashed
+run cannot leave partially overwritten files. For resumable append-only
+pipelines, `trim_corrupt_tail` plus a list of companion files keeps
+several parallel outputs aligned after a crash.
+
 ## Out of scope
 
 To keep the package lean and dependency-free at its core, `convmerge` does
@@ -123,21 +177,34 @@ To keep the package lean and dependency-free at its core, `convmerge` does
 - **Model loading / inference / training.** No PyTorch, Transformers, vLLM,
   or similar runtime is imported by the core or any shipped extra.
 - **Automatic labeling or classification of samples** (e.g. topic tagging,
-  quality scoring, safety classification). These are left to upstream tools
-  or private pipelines.
+  quality scoring, safety classification). Concretely: no Anthropic / OpenAI
+  batch-evaluation clients, no identity or safety scoring. Those belong in
+  upstream tools or private pipelines.
 - **RLHF / DPO / preference-dataset construction** beyond passing through
   existing pairwise rows via the `chat` adapter's `pairwise_mode`.
 - **Training-job orchestration** (SkyPilot, RunPod, Modal, K8s operators).
+  No RunPod / GraphQL / worker-pool management lives here.
 - **Prompt templating / chat-template rendering** for specific model
   families. Output JSONL uses the standard `messages` / `alpaca` shapes;
   downstream trainers apply their own template.
 - **Tokenizer-aware length filtering, packing, or curriculum scheduling.**
-  Those live in the training stack, not here.
+  Those live in the training stack, not here. The library never imports a
+  tokenizer (e.g. `transformers.AutoTokenizer`) at any layer.
+- **Dataset-hosting integrations that require a remote account** —
+  specifically, no HuggingFace Hub *upload* path. `fetch` uses the
+  HuggingFace `datasets` library read-only to pull down splits; publishing
+  a cleaned dataset is your pipeline's concern, not `convmerge`'s.
+- **Product-specific transforms** (e.g. per-persona rewrites, bespoke
+  translation flows tied to a particular model / company). The library
+  exposes generic primitives; wire your own rewriter on top.
 - **Scraping HTML pages or running browser automation.** Structured JSON /
   JSONL / Parquet inputs only.
 
 If any of these are important to your workflow, wire `convmerge` in as one
 step of a larger pipeline rather than expecting it to grow into those areas.
+The [`pipeline.build_sft_jsonl`](src/convmerge/pipeline.py) function is a
+deliberate, local-filesystem-only orchestrator: everything after it (upload,
+labeling, training) is the caller's responsibility.
 
 ## Development
 

--- a/docs/migration-0.3.md
+++ b/docs/migration-0.3.md
@@ -1,0 +1,124 @@
+# Migrating notebook-resident SFT prep code to convmerge 0.3
+
+`convmerge 0.3` promotes a number of directory-level preprocessing helpers
+that previously lived inside analyst notebooks (hand-rolled `sync_*`,
+`merge_*`, `split_*`, and resume helpers). The library API is now rich
+enough that those notebook cells can be deleted in favour of a handful
+of imports.
+
+This document is for notebook maintainers opening a **follow-up PR** that
+replaces the duplicated utility cells. It is purposely mechanical; each
+row below says "delete cell X, replace with this import + these two
+lines".
+
+## 1. Replace file-system utility cells
+
+| Delete cell                            | Replace with                                                |
+| -------------------------------------- | ----------------------------------------------------------- |
+| `remove_endwith(suffixes, dir_path)`   | `from convmerge.normalize import prune_by_suffix`           |
+| `print_first_line_each_file(...)`      | `from convmerge.normalize import head_preview, head_preview_dir` |
+| `find_single_line_jsonl(...)`          | `from convmerge.normalize import scan_shapes`               |
+| `filter_data(dir_path, out_dir)`       | `from convmerge.normalize import normalize_dir`             |
+
+Call site examples:
+
+```python
+from convmerge.normalize import normalize_dir, prune_by_suffix, scan_shapes
+
+normalize_dir(RAW_DIR, JSONL_DIR)
+prune_by_suffix(JSONL_DIR, ["-res.jsonl", "config.jsonl", "_infos.jsonl"])
+shapes = scan_shapes(JSONL_DIR)
+```
+
+## 2. Replace multi-turn schema unification cells
+
+| Delete                                                 | Replace                                                    |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| `sync_multi_turn_files_for_list(...)` + `transform_line` | `convmerge.normalize.reshape.unify_messages_dir`           |
+| `sync_message_format(...)`                             | `convmerge.normalize.reshape.unify_message_entries`        |
+| `parse_tagged_text_to_messages(...)`                   | `convmerge.normalize.reshape.parse_tagged_text`            |
+| `check_multi_turn`, `_looks_like_chat_row`             | `convmerge.normalize.reshape.classify_row_shape`           |
+
+Drop the hard-coded `_SFT_STRIP_TOP_LEVEL_KEYS` frozenset; pass
+`sft_strip_keys=` to `unify_messages_dir` (or rely on its default, which
+covers LMSYS / WildChat / Arena metadata fields).
+
+```python
+from convmerge.normalize.reshape import (
+    unify_messages_dir, unify_message_entries,
+)
+
+unify_messages_dir(
+    JSONL_DIR, MULT_TURN_DIR,
+    adapter_kwargs={"conversation_keys": ("messages", "conversation", "conversations", "text")},
+)
+unify_message_entries(MULT_TURN_DIR, MULT_TURN_DIR, source_keys=("from",),  target_key="role")
+unify_message_entries(MULT_TURN_DIR, MULT_TURN_DIR, source_keys=("value",), target_key="content")
+```
+
+## 3. Replace single-turn schema unification cells
+
+| Delete                                | Replace                                                    |
+| ------------------------------------- | ---------------------------------------------------------- |
+| `normalize_single_turn_record(...)`   | `convmerge.adapters.alpaca.remap_to_alpaca`                |
+| `sync_single_turn_files(...)`         | `convmerge.normalize.reshape.unify_alpaca_dir`             |
+| `single_turn_to_multi_turn_record`    | (covered by `convert_file` with the `alpaca` adapter)      |
+| `sync_single_turn_to_multi_turn(...)` | `convmerge.convert.convert_dir(adapter_name="alpaca", output_format="messages")` |
+
+## 4. Replace merge / split / dedupe / turn-filter cells
+
+| Delete                          | Replace                                        |
+| ------------------------------- | ---------------------------------------------- |
+| `merge_jsonl(file_paths, out)`  | `convmerge.normalize.merge.merge_jsonl`        |
+| `collect_all_samples(dirs, out)`| `convmerge.normalize.merge.collect_jsonl_tree` |
+| `filter_empty_turns(src, dst)`  | `convmerge.normalize.filter_by_min_turns`      |
+| `duplication_filter(...)`       | `convmerge.normalize.deduplicate_jsonl`        |
+| `split_dataset(...)` (numpy)    | `convmerge.normalize.split.train_test_split` (pure Python; numpy is **not** required) |
+
+## 5. Replace sampling / resume helpers in `refine.ipynb`
+
+| Delete                                      | Replace                                           |
+| ------------------------------------------- | ------------------------------------------------- |
+| `sample_jsonl_random_lines(...)`            | `convmerge.normalize.sample.sample_random` (or `reservoir_sample` for streaming) |
+| `_jsonl_line_count(...)`                    | `convmerge.normalize.resume.count_lines`          |
+| `_truncate_jsonl_to_n_lines(...)`           | `convmerge.normalize.resume.truncate_to_n_lines`  |
+| `_trim_corrupt_bundle_tail_and_splits(...)` | `convmerge.normalize.resume.trim_corrupt_tail(path, companions=(...))` |
+
+## 6. Optional: collapse the whole pipeline into one call
+
+If your notebook's cell 15 is exactly the `normalize → reshape → convert
+→ merge → dedupe → filter_by_min_turns → train_test_split` chain, replace
+the whole cell with:
+
+```python
+from convmerge.pipeline import build_sft_jsonl
+
+result = build_sft_jsonl(
+    raw_dir=RAW_DIR,
+    out_dir=OUT_DIR,
+    prune_suffixes=("-res.jsonl", "config.jsonl", "_infos.jsonl"),
+    train_ratio=0.98,
+    seed=42,
+    min_turns=1,
+)
+TRAIN_PATH = result.train_path
+TEST_PATH  = result.test_path
+```
+
+## 7. What stays in the notebooks
+
+These pieces are **product-specific** and intentionally out of scope for
+`convmerge`. Keep them in the notebook, but import the generic primitives
+above instead of re-implementing them:
+
+- RunPod worker-pool orchestration / GraphQL polling / batch classify
+  (filter.ipynb cells 10, 18).
+- HuggingFace Hub upload, `prepare_hf_dataset_repo`, README / card
+  generation (filter.ipynb cells 12, 13, 16, 17).
+- Anthropic identity / safety batch evaluation, MD / HTML reports
+  (refine.ipynb cells 3–7).
+- Neura rewrite / translate client, Neura system prompt, Qwen-specific
+  tokenizer counting (refine.ipynb cells 2, 8, 9, 10).
+
+See the [`Out of scope`](../README.md#out-of-scope) section of the README
+for the reasoning.

--- a/examples/recipes/build_sft_from_mixed_jsonl.py
+++ b/examples/recipes/build_sft_from_mixed_jsonl.py
@@ -1,0 +1,57 @@
+"""Minimal end-to-end SFT dataset recipe using only convmerge primitives.
+
+Run:
+
+    python examples/recipes/build_sft_from_mixed_jsonl.py ./raw ./out
+
+Expected layout under ``./raw/``:
+
+- ``./raw/<any>.json``    (top-level array of alpaca or messages objects)
+- ``./raw/<any>.jsonl``   (one alpaca / messages / sharegpt object per line)
+- ``./raw/<any>.parquet`` (needs the ``convmerge[parquet]`` extra)
+
+Produces:
+
+- ``./out/final/train.jsonl`` / ``./out/final/test.jsonl`` — messages-shaped.
+- Intermediate trees under ``./out/{jsonl,multi_turn,single_turn,final}``
+  so you can inspect each stage.
+
+This recipe does NOT upload anywhere, call any model, or run labeling. If
+you need those steps, wrap ``build_sft_jsonl`` from your own script.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from convmerge.pipeline import build_sft_jsonl
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    raw_dir = Path(argv[1])
+    out_dir = Path(argv[2])
+
+    result = build_sft_jsonl(
+        raw_dir=raw_dir,
+        out_dir=out_dir,
+        # Typical junk files that come out of HF dumps; tune for your dataset.
+        prune_suffixes=("-res.jsonl", "config.jsonl", "_infos.jsonl"),
+        train_ratio=0.98,
+        seed=42,
+        min_turns=1,
+    )
+
+    print("== counts ==")
+    for k, v in result.counts.items():
+        print(f"  {k:>22s}: {v:,}")
+    print(f"train -> {result.train_path}")
+    print(f"test  -> {result.test_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "convmerge"
-version = "0.2.1"
+version = "0.3.0"
 description = "Fetch, normalize, and convert heterogeneous chat/instruct datasets into a single LLM training format"
 readme = "README.md"
 license = "MIT"

--- a/src/convmerge/__init__.py
+++ b/src/convmerge/__init__.py
@@ -1,3 +1,3 @@
 """convmerge — merge heterogeneous sources into a single LLM training format."""
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/src/convmerge/adapters/__init__.py
+++ b/src/convmerge/adapters/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 from typing import Any
 
-from convmerge.adapters.alpaca import iter_from_alpaca_line
+from convmerge.adapters.alpaca import iter_from_alpaca_line, remap_to_alpaca
 from convmerge.adapters.chat import iter_from_chat_line
 from convmerge.adapters.sharegpt import iter_from_sharegpt_line
 from convmerge.models import TrainingExample
@@ -26,3 +26,14 @@ def get_adapter(name: str) -> AdapterFn:
         known = ", ".join(sorted(ADAPTERS))
         raise ValueError(f"Unknown adapter {name!r}. Choose one of: {known}")
     return ADAPTERS[name]
+
+
+__all__ = [
+    "ADAPTERS",
+    "AdapterFn",
+    "get_adapter",
+    "iter_from_alpaca_line",
+    "iter_from_chat_line",
+    "iter_from_sharegpt_line",
+    "remap_to_alpaca",
+]

--- a/src/convmerge/adapters/alpaca.py
+++ b/src/convmerge/adapters/alpaca.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from convmerge.models import ChatMessage, TrainingExample
+
+DEFAULT_INSTRUCTION_KEYS: tuple[str, ...] = ("instruction", "question", "prompt")
+DEFAULT_OUTPUT_KEYS: tuple[str, ...] = ("output", "response", "answer", "solution")
+DEFAULT_INPUT_KEYS: tuple[str, ...] = ("input", "context")
 
 
 def iter_from_alpaca_line(record: dict[str, Any]) -> Iterator[TrainingExample]:
@@ -36,3 +40,46 @@ def iter_from_alpaca_line(record: dict[str, Any]) -> Iterator[TrainingExample]:
         return
 
     yield TrainingExample(messages=messages, meta={"source": "alpaca"})
+
+
+def remap_to_alpaca(
+    record: dict[str, Any],
+    *,
+    instruction_keys: Iterable[str] = DEFAULT_INSTRUCTION_KEYS,
+    output_keys: Iterable[str] = DEFAULT_OUTPUT_KEYS,
+    input_keys: Iterable[str] = DEFAULT_INPUT_KEYS,
+    drop_keys: Iterable[str] = (),
+) -> dict[str, Any] | None:
+    """Pull an alpaca-shaped record out of a messy single-turn row.
+
+    For each slot (instruction / output / input) the first key from the
+    corresponding priority list that is present on ``record`` wins. ``drop_keys``
+    are ignored (useful for per-source ids / urls that you don't want to
+    carry downstream).
+
+    Returns a fresh ``{"instruction", "input", "output"}`` dict, or ``None``
+    when no usable instruction/output pair can be assembled.
+    """
+    obj = dict(record)
+    for k in drop_keys:
+        obj.pop(k, None)
+
+    instr = _first_nonempty_str(obj, instruction_keys)
+    output = _first_nonempty_str(obj, output_keys)
+    if instr is None or output is None:
+        return None
+
+    inp = _first_nonempty_str(obj, input_keys) or ""
+    return {
+        "instruction": instr,
+        "input": inp,
+        "output": output,
+    }
+
+
+def _first_nonempty_str(record: dict[str, Any], keys: Iterable[str]) -> str | None:
+    for k in keys:
+        v = record.get(k)
+        if isinstance(v, str) and v.strip():
+            return v
+    return None

--- a/src/convmerge/adapters/chat.py
+++ b/src/convmerge/adapters/chat.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Any
 
-from convmerge.adapters.alpaca import iter_from_alpaca_line
+from convmerge.adapters.alpaca import iter_from_alpaca_line, remap_to_alpaca
 from convmerge.models import ChatMessage, TrainingExample
 
 # Default mapping from common ShareGPT-style ``from`` values onto standard roles.
@@ -97,7 +97,12 @@ def iter_from_chat_line(
         return
 
     # Fall back to the alpaca adapter, but let callers override the key priority.
-    remapped = _remap_for_alpaca(record, instruction_keys, input_keys, output_keys)
+    remapped = remap_to_alpaca(
+        record,
+        instruction_keys=instruction_keys,
+        input_keys=input_keys,
+        output_keys=output_keys,
+    )
     if remapped is not None:
         yield from iter_from_alpaca_line(remapped)
 
@@ -176,30 +181,3 @@ def _coerce_messages(
             continue
         out.append(ChatMessage(role=role, content=content))
     return out
-
-
-def _remap_for_alpaca(
-    record: dict[str, Any],
-    instruction_keys: tuple[str, ...],
-    input_keys: tuple[str, ...],
-    output_keys: tuple[str, ...],
-) -> dict[str, Any] | None:
-    """Pick the first matching key for each slot and return a standard alpaca row."""
-    instr = _first_string(record, instruction_keys)
-    out = _first_string(record, output_keys)
-    if instr is None and out is None:
-        return None
-    inp = _first_string(record, input_keys) or ""
-    return {
-        "instruction": instr or "",
-        "input": inp,
-        "output": out or "",
-    }
-
-
-def _first_string(record: dict[str, Any], keys: tuple[str, ...]) -> str | None:
-    for k in keys:
-        v = record.get(k)
-        if isinstance(v, str) and v.strip():
-            return v
-    return None

--- a/src/convmerge/cli.py
+++ b/src/convmerge/cli.py
@@ -27,6 +27,14 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_turns(args)
     elif args.command == "fetch":
         _cmd_fetch(args)
+    elif args.command == "merge":
+        _cmd_merge(args)
+    elif args.command == "split":
+        _cmd_split(args)
+    elif args.command == "sample":
+        _cmd_sample(args)
+    elif args.command == "build":
+        _cmd_build(args)
     else:  # pragma: no cover - argparse enforces ``required=True``
         parser.error(f"unknown command: {args.command}")
 
@@ -47,6 +55,10 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_dedupe(subparsers)
     _add_turns(subparsers)
     _add_fetch(subparsers)
+    _add_merge(subparsers)
+    _add_split(subparsers)
+    _add_sample(subparsers)
+    _add_build(subparsers)
 
     return parser
 
@@ -361,6 +373,159 @@ def _with_overridden_defaults(manifest, *, on_error, resume):
     if resume is not None:
         new_defaults = replace(new_defaults, resume=resume)
     return replace(manifest, defaults=new_defaults)
+
+
+def _add_merge(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "merge",
+        help="Concatenate JSONL files (or whole directory trees) into one JSONL",
+    )
+    p.add_argument(
+        "--input", "-i", type=Path, nargs="+", required=True, help="Files or directories"
+    )
+    p.add_argument("--output", "-o", type=Path, required=True)
+    p.add_argument(
+        "--validate",
+        action="store_true",
+        help="Drop lines that fail to parse as JSON instead of copying them verbatim",
+    )
+
+
+def _cmd_merge(args: argparse.Namespace) -> None:
+    from convmerge.normalize.merge import collect_jsonl_tree, merge_jsonl
+
+    sources: list[Path] = list(args.input)
+    dirs = [p for p in sources if p.is_dir()]
+    files = [p for p in sources if p.is_file()]
+
+    total = 0
+    if dirs:
+        written, skipped = collect_jsonl_tree(dirs, args.output, validate=args.validate)
+        total += written
+        if skipped:
+            print(f"[merge] skipped {skipped} unparsable lines from tree input", file=sys.stderr)
+    if files:
+        # Append file-based sources to the tree output by merging into a temp and concatenating.
+        if dirs:
+            # Append mode: read existing and extend.
+            with args.output.open("a", encoding="utf-8") as wf:
+                for fp in files:
+                    with fp.open(encoding="utf-8") as rf:
+                        for line in rf:
+                            raw = line.strip()
+                            if not raw:
+                                continue
+                            if args.validate:
+                                try:
+                                    import json as _json
+
+                                    _json.loads(raw)
+                                except Exception:
+                                    continue
+                            wf.write(raw + "\n")
+                            total += 1
+        else:
+            written = merge_jsonl(files, args.output, validate=args.validate)
+            total += written
+
+    print(f"[merge] wrote {total:,} lines -> {args.output}", file=sys.stderr)
+
+
+def _add_split(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "split",
+        help="Shuffle-split a JSONL file into train / test (pure Python, seeded)",
+    )
+    p.add_argument("--input", "-i", type=Path, required=True)
+    p.add_argument("--out-dir", "-o", type=Path, required=True)
+    p.add_argument("--train-ratio", type=float, default=0.98)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--max-samples", type=int, default=None)
+    p.add_argument("--train-name", default="train.jsonl")
+    p.add_argument("--test-name", default="test.jsonl")
+
+
+def _cmd_split(args: argparse.Namespace) -> None:
+    from convmerge.normalize.split import train_test_split
+
+    train_path, test_path, n_tr, n_te = train_test_split(
+        args.input,
+        args.out_dir,
+        train_ratio=args.train_ratio,
+        seed=args.seed,
+        max_samples=args.max_samples,
+        train_name=args.train_name,
+        test_name=args.test_name,
+    )
+    print(f"[split] train: {n_tr:,} -> {train_path}", file=sys.stderr)
+    print(f"[split] test:  {n_te:,} -> {test_path}", file=sys.stderr)
+
+
+def _add_sample(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "sample",
+        help="Randomly sample k lines from a JSONL file",
+    )
+    p.add_argument("--input", "-i", type=Path, required=True)
+    p.add_argument("--output", "-o", type=Path, required=True)
+    p.add_argument("-k", type=int, required=True, help="Number of lines to sample")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--reservoir",
+        action="store_true",
+        help="Use reservoir sampling (streaming, memory-bounded) instead of in-memory sampling",
+    )
+
+
+def _cmd_sample(args: argparse.Namespace) -> None:
+    from convmerge.normalize.sample import reservoir_sample, sample_random
+
+    fn = reservoir_sample if args.reservoir else sample_random
+    written, total = fn(args.input, args.output, k=args.k, seed=args.seed)
+    print(f"[sample] wrote {written:,} / {total:,} lines -> {args.output}", file=sys.stderr)
+
+
+def _add_build(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "build",
+        help=(
+            "End-to-end SFT prep: raw -> jsonl -> reshape -> convert -> merge "
+            "-> dedupe -> filter -> train/test split"
+        ),
+    )
+    p.add_argument("--raw", "-r", type=Path, required=True, help="Raw input directory")
+    p.add_argument("--out", "-o", type=Path, required=True, help="Output directory")
+    p.add_argument(
+        "--prune-suffix",
+        nargs="*",
+        default=(),
+        help="Drop files whose names end with these suffixes after normalize",
+    )
+    p.add_argument("--train-ratio", type=float, default=0.98)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--min-turns", type=int, default=1)
+    p.add_argument("--max-samples", type=int, default=None)
+    p.add_argument("--dedupe-algorithm", default="md5", choices=("md5", "sha256"))
+
+
+def _cmd_build(args: argparse.Namespace) -> None:
+    from convmerge.pipeline import build_sft_jsonl
+
+    result = build_sft_jsonl(
+        raw_dir=args.raw,
+        out_dir=args.out,
+        prune_suffixes=tuple(args.prune_suffix),
+        train_ratio=args.train_ratio,
+        seed=args.seed,
+        min_turns=args.min_turns,
+        max_samples=args.max_samples,
+        dedupe_algorithm=args.dedupe_algorithm,
+    )
+    print("[build] counts:", file=sys.stderr)
+    for k, v in result.counts.items():
+        print(f"  {k}: {v:,}", file=sys.stderr)
+    print(f"[build] train -> {result.train_path}", file=sys.stderr)
+    print(f"[build] test  -> {result.test_path}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/src/convmerge/convert.py
+++ b/src/convmerge/convert.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
+from typing import Literal
 
 from convmerge.adapters import get_adapter
 from convmerge.emitters import get_emitter
@@ -72,3 +73,57 @@ def iter_converted_lines(
             continue
         for example in adapter(obj):
             yield json.dumps(emitter(example), ensure_ascii=False)
+
+
+def convert_dir(
+    src_dir: str | Path,
+    dst_dir: str | Path,
+    *,
+    adapter_name: str,
+    output_format: str,
+    extensions: Iterable[str] = (".jsonl",),
+    on_error: Literal["skip", "raise"] = "skip",
+    encoding: str = "utf-8",
+) -> tuple[int, int, int]:
+    """Recursively run :func:`convert_file` over every JSONL under ``src_dir``.
+
+    Relative paths are preserved under ``dst_dir``. Files whose suffix is not
+    in ``extensions`` (case-insensitive) are ignored.
+
+    Returns ``(n_files, total_read, total_written)``.
+    """
+    src_p = Path(src_dir)
+    dst_p = Path(dst_dir)
+    if not src_p.is_dir():
+        raise NotADirectoryError(f"Not a directory: {src_p}")
+
+    exts = tuple(e.lower() for e in extensions)
+    n_files = 0
+    total_read = 0
+    total_written = 0
+
+    for in_path in sorted(src_p.rglob("*")):
+        if not in_path.is_file():
+            continue
+        if in_path.suffix.lower() not in exts:
+            continue
+        rel = in_path.relative_to(src_p)
+        out_path = dst_p / rel
+        try:
+            n_in, n_out = convert_file(
+                in_path,
+                out_path,
+                adapter_name=adapter_name,
+                output_format=output_format,
+                encoding=encoding,
+            )
+        except Exception as e:  # noqa: BLE001
+            if on_error == "raise":
+                raise
+            print(f"[fail] {in_path}: {type(e).__name__}: {e}")
+            continue
+        n_files += 1
+        total_read += n_in
+        total_written += n_out
+
+    return n_files, total_read, total_written

--- a/src/convmerge/normalize/__init__.py
+++ b/src/convmerge/normalize/__init__.py
@@ -2,7 +2,8 @@
 
 Turn messy chat/instruct dataset files (parquet, JSON arrays, single-line JSONL,
 mixed schemas) into clean newline-delimited JSONL, and provide building blocks
-for turn-count analysis, deduplication, and single-turn <-> multi-turn conversion.
+for turn-count analysis, deduplication, sampling, merging, splitting, and
+schema reshaping.
 """
 
 from __future__ import annotations
@@ -14,30 +15,74 @@ from convmerge.normalize.convert_turns import (
 from convmerge.normalize.dedup import deduplicate_jsonl
 from convmerge.normalize.jsonl import (
     detect_jsonl_shape,
+    head_preview,
+    head_preview_dir,
     iter_json_records,
     load_jsonl,
+    normalize_dir,
     normalize_to_jsonl,
+    prune_by_suffix,
+    scan_shapes,
 )
+from convmerge.normalize.merge import collect_jsonl_tree, merge_jsonl
+from convmerge.normalize.reshape import (
+    DEFAULT_SFT_STRIP_KEYS,
+    DEFAULT_TAG_MAP,
+    classify_row_shape,
+    parse_tagged_text,
+    unify_alpaca_dir,
+    unify_message_entries,
+    unify_messages_dir,
+)
+from convmerge.normalize.resume import (
+    count_lines,
+    trim_corrupt_tail,
+    truncate_to_n_lines,
+)
+from convmerge.normalize.sample import reservoir_sample, sample_random
 from convmerge.normalize.schema import is_uniform_schema, key_frequency
+from convmerge.normalize.split import train_test_split
 from convmerge.normalize.turns import (
     analyze_turn_distribution,
     count_turns,
+    filter_by_min_turns,
     is_single_turn,
     split_by_turns,
 )
 
 __all__ = [
+    "DEFAULT_SFT_STRIP_KEYS",
+    "DEFAULT_TAG_MAP",
     "analyze_turn_distribution",
+    "classify_row_shape",
+    "collect_jsonl_tree",
+    "count_lines",
     "count_turns",
     "deduplicate_jsonl",
     "detect_jsonl_shape",
+    "filter_by_min_turns",
+    "head_preview",
+    "head_preview_dir",
     "is_single_turn",
     "is_uniform_schema",
     "iter_json_records",
     "key_frequency",
     "load_jsonl",
+    "merge_jsonl",
     "multi_turn_to_single_turn_record",
+    "normalize_dir",
     "normalize_to_jsonl",
+    "parse_tagged_text",
+    "prune_by_suffix",
+    "reservoir_sample",
+    "sample_random",
+    "scan_shapes",
     "single_turn_to_multi_turn_record",
     "split_by_turns",
+    "train_test_split",
+    "trim_corrupt_tail",
+    "truncate_to_n_lines",
+    "unify_alpaca_dir",
+    "unify_message_entries",
+    "unify_messages_dir",
 ]

--- a/src/convmerge/normalize/jsonl.py
+++ b/src/convmerge/normalize/jsonl.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any, Literal
 
@@ -11,6 +11,12 @@ JSONLShape = Literal["jsonl", "single_line", "json_array", "invalid", "empty"]
 
 # Bytes scanned from the head of a file to decide its shape without loading everything.
 _HEAD_PEEK_BYTES = 65536
+
+# File extensions recognised by the directory-level sweeps below.
+NORMALIZE_EXTENSIONS: tuple[str, ...] = (".parquet", ".json", ".jsonl")
+
+# Max bytes read from the head of a file by :func:`head_preview` when no newline is found.
+_HEAD_PREVIEW_DEFAULT_BYTES = 8192
 
 
 def load_jsonl(path: str | Path, *, max_rows: int | None = None) -> list[dict[str, Any]]:
@@ -210,4 +216,181 @@ def _split_concatenated_objects(text: str) -> list[Any]:
         obj, end = decoder.raw_decode(text, i)
         out.append(obj)
         i = end
+    return out
+
+
+def normalize_dir(
+    src_dir: str | Path,
+    dst_dir: str | Path,
+    *,
+    extensions: Iterable[str] = NORMALIZE_EXTENSIONS,
+    on_error: Literal["skip", "raise"] = "skip",
+    overwrite: bool = True,
+) -> tuple[int, int]:
+    """Recursively normalize parquet/json/jsonl files under a directory tree.
+
+    Each matching file under ``src_dir`` is converted into a ``.jsonl`` file at
+    the mirrored path under ``dst_dir``. Parquet files are streamed via
+    :func:`convmerge.normalize.parquet.parquet_to_jsonl` (requires the
+    ``parquet`` extra); json / jsonl files are funnelled through
+    :func:`normalize_to_jsonl`.
+
+    Returns ``(n_files, n_records)`` — how many files were written and the
+    total number of records across them.
+
+    ``on_error='skip'`` (the default) prints a failure line and continues;
+    ``on_error='raise'`` re-raises the first exception.
+    """
+    src_p = Path(src_dir)
+    dst_p = Path(dst_dir)
+    if not src_p.is_dir():
+        raise NotADirectoryError(f"Not a directory: {src_p}")
+
+    exts_lower = tuple(e.lower() for e in extensions)
+    n_files = 0
+    n_records = 0
+
+    for in_path in sorted(src_p.rglob("*")):
+        if not in_path.is_file():
+            continue
+        suffix = in_path.suffix.lower()
+        if suffix not in exts_lower:
+            continue
+        rel = in_path.relative_to(src_p).with_suffix(".jsonl")
+        out_path = dst_p / rel
+        if out_path.exists():
+            if overwrite:
+                try:
+                    out_path.unlink()
+                except OSError:
+                    pass
+            else:
+                continue
+        try:
+            n = _normalize_any(in_path, out_path)
+        except Exception as e:  # noqa: BLE001
+            if on_error == "raise":
+                raise
+            print(f"[fail] {in_path}: {type(e).__name__}: {e}")
+            continue
+        n_files += 1
+        n_records += n
+
+    return n_files, n_records
+
+
+def _normalize_any(src: Path, dst: Path) -> int:
+    """Dispatch a single file to the right normalizer based on extension."""
+    suffix = src.suffix.lower()
+    if suffix == ".parquet":
+        # Imported lazily so callers that never touch parquet do not need
+        # the ``parquet`` extra.
+        from convmerge.normalize.parquet import parquet_to_jsonl
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        return parquet_to_jsonl(src, dst)
+    return normalize_to_jsonl(src, dst)
+
+
+def prune_by_suffix(
+    dir_path: str | Path,
+    suffixes: Iterable[str],
+    *,
+    dry_run: bool = False,
+) -> list[Path]:
+    """Recursively delete files whose filename ends with any of ``suffixes``.
+
+    Intended for removing dataset-level junk files like ``*-res.jsonl`` or
+    ``config.jsonl`` that slip through a bulk download. With ``dry_run=True``,
+    returns the list of matching paths without deleting them.
+
+    Returns the list of paths that were removed (or would be removed).
+    """
+    root = Path(dir_path)
+    if not root.is_dir():
+        raise NotADirectoryError(f"Not a directory: {root}")
+    tail: tuple[str, ...] = tuple(suffixes)
+    if not tail:
+        return []
+
+    removed: list[Path] = []
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        name = p.name
+        if not any(name.endswith(t) for t in tail):
+            continue
+        removed.append(p)
+        if not dry_run:
+            try:
+                p.unlink()
+            except OSError as e:
+                print(f"[prune_by_suffix] cannot remove {p}: {e}")
+    return removed
+
+
+def head_preview(path: str | Path, *, max_bytes: int = _HEAD_PREVIEW_DEFAULT_BYTES) -> str:
+    """Return the first line (or the first ``max_bytes`` bytes) of a file as text.
+
+    Useful for "what does this file look like?" sanity checks on large raw
+    dumps without loading them. Binary bytes are decoded leniently.
+    """
+    p = Path(path)
+    with p.open("rb") as f:
+        chunk = f.read(max_bytes)
+    text = chunk.decode("utf-8", errors="ignore")
+    if "\n" in text:
+        return text.split("\n", 1)[0]
+    return text if len(chunk) < max_bytes else text + "..."
+
+
+def head_preview_dir(
+    dir_path: str | Path,
+    *,
+    extensions: Iterable[str] | None = None,
+    max_bytes: int = _HEAD_PREVIEW_DEFAULT_BYTES,
+) -> dict[Path, str]:
+    """Run :func:`head_preview` on every file under a directory tree.
+
+    If ``extensions`` is given, only files whose suffix matches are previewed
+    (case-insensitive). The result is keyed by the original file path.
+    """
+    root = Path(dir_path)
+    if not root.is_dir():
+        raise NotADirectoryError(f"Not a directory: {root}")
+    exts = tuple(e.lower() for e in extensions) if extensions else None
+
+    out: dict[Path, str] = {}
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        if exts is not None and p.suffix.lower() not in exts:
+            continue
+        out[p] = head_preview(p, max_bytes=max_bytes)
+    return out
+
+
+def scan_shapes(
+    dir_path: str | Path,
+    *,
+    extensions: Iterable[str] = (".json", ".jsonl"),
+) -> dict[Path, JSONLShape]:
+    """Classify every ``.json`` / ``.jsonl`` file under a directory by shape.
+
+    Returns a mapping of path -> :data:`JSONLShape`. Use alongside
+    :func:`normalize_dir` to audit what a raw dump actually contains before
+    committing to a pipeline.
+    """
+    root = Path(dir_path)
+    if not root.is_dir():
+        raise NotADirectoryError(f"Not a directory: {root}")
+    exts = tuple(e.lower() for e in extensions)
+
+    out: dict[Path, JSONLShape] = {}
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        if p.suffix.lower() not in exts:
+            continue
+        out[p] = detect_jsonl_shape(p)
     return out

--- a/src/convmerge/normalize/merge.py
+++ b/src/convmerge/normalize/merge.py
@@ -1,0 +1,102 @@
+"""Merge multiple JSONL files (or whole trees) into a single JSONL file."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def merge_jsonl(
+    sources: Iterable[str | Path],
+    dst: str | Path,
+    *,
+    skip_blank: bool = True,
+    validate: bool = False,
+) -> int:
+    """Concatenate ``sources`` into a single JSONL file at ``dst``.
+
+    Missing source files are silently skipped so callers can pass an
+    optimistic list. With ``validate=True`` every non-blank line is parsed
+    first; unparsable lines are dropped instead of being copied verbatim
+    (useful when upstream files may contain binary garbage).
+
+    Returns the number of lines written.
+    """
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    total = 0
+    with dst_p.open("w", encoding="utf-8") as wf:
+        for s in sources:
+            src_p = Path(s)
+            if not src_p.is_file():
+                continue
+            with src_p.open(encoding="utf-8") as rf:
+                for raw in rf:
+                    line = raw.strip()
+                    if not line:
+                        if skip_blank:
+                            continue
+                        wf.write("\n")
+                        total += 1
+                        continue
+                    if validate:
+                        try:
+                            json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                    wf.write(line + "\n")
+                    total += 1
+    return total
+
+
+def collect_jsonl_tree(
+    source_dirs: Iterable[str | Path],
+    dst: str | Path,
+    *,
+    extensions: Iterable[str] = (".jsonl",),
+    validate: bool = True,
+) -> tuple[int, int]:
+    """Collect every ``*.jsonl`` file under ``source_dirs`` into one JSONL.
+
+    Each directory is walked recursively; files whose suffix matches
+    ``extensions`` (case-insensitive) are concatenated into ``dst``. Missing
+    directories are skipped (with a stderr-style warning kept out of stdout)
+    so callers can hand in an optimistic list.
+
+    Returns ``(written, skipped_broken)`` — how many lines landed in ``dst``
+    and how many lines were dropped because they did not parse as JSON
+    (only counted when ``validate=True``).
+    """
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    exts = tuple(e.lower() for e in extensions)
+    files: list[Path] = []
+    for d in source_dirs:
+        d_p = Path(d)
+        if not d_p.is_dir():
+            continue
+        for p in d_p.rglob("*"):
+            if p.is_file() and p.suffix.lower() in exts:
+                files.append(p)
+
+    written = 0
+    skipped = 0
+    with dst_p.open("w", encoding="utf-8") as wf:
+        for path in files:
+            with path.open(encoding="utf-8") as rf:
+                for raw in rf:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    if validate:
+                        try:
+                            json.loads(line)
+                        except json.JSONDecodeError:
+                            skipped += 1
+                            continue
+                    wf.write(line + "\n")
+                    written += 1
+    return written, skipped

--- a/src/convmerge/normalize/reshape.py
+++ b/src/convmerge/normalize/reshape.py
@@ -1,0 +1,382 @@
+"""Directory-level schema unification for chat / alpaca JSONL trees.
+
+The row-level primitives live in :mod:`convmerge.adapters.chat` and
+:mod:`convmerge.adapters.alpaca`. This module wraps them into
+"walk a directory, rewrite every file in place (safely), preserve the tree"
+operations that dataset preparation pipelines typically need, without
+imposing any particular hard-coded schema.
+
+All helpers support the "same source and target directory" pattern by
+writing into a temp directory first and moving files back after all
+sources are processed — so a crashed run cannot leave partially overwritten
+files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Literal
+
+from convmerge.adapters.alpaca import (
+    DEFAULT_INPUT_KEYS,
+    DEFAULT_INSTRUCTION_KEYS,
+    DEFAULT_OUTPUT_KEYS,
+    remap_to_alpaca,
+)
+from convmerge.adapters.chat import iter_from_chat_line
+
+# Common keys that carry moderation / provenance metadata on public chat
+# datasets (LMSYS, WildChat, Chatbot Arena, …). Passed to
+# :func:`unify_messages_dir` by default so users can override per project.
+DEFAULT_SFT_STRIP_KEYS: frozenset[str] = frozenset(
+    {
+        "openai_moderation",
+        "detoxify_moderation",
+        "conversation_id",
+        "model",
+        "turn",
+        "language",
+        "redacted",
+        "timestamp",
+        "toxic",
+        "model_a",
+        "model_b",
+        "winner",
+        "question_id",
+        "conversation_a",
+        "conversation_b",
+        "conversation",
+        "conversations",
+        "text",
+        "user_id",
+        "anonymized_user_id",
+        "uid",
+        "tstamp",
+        "judge",
+        "anony",
+        "toxic_chat_tag",
+    }
+)
+
+# Default mapping for tagged-text chat dumps (``<sys>...\n<usr>...\n<bot>...``).
+DEFAULT_TAG_MAP: dict[str, str] = {
+    "sys": "system",
+    "usr": "user",
+    "bot": "assistant",
+}
+
+RowShape = Literal["chat", "pairwise", "alpaca", "plain_text", "unknown"]
+
+
+def classify_row_shape(
+    row: dict[str, Any],
+    *,
+    instruction_keys: Iterable[str] = DEFAULT_INSTRUCTION_KEYS,
+    output_keys: Iterable[str] = DEFAULT_OUTPUT_KEYS,
+) -> RowShape:
+    """Best-effort classification of a single JSON row into a schema family.
+
+    The result is a loose signal, not a guarantee:
+
+    - ``"pairwise"`` : ``conversation_a`` / ``conversation_b`` present.
+    - ``"chat"``     : any of ``messages`` / ``conversation`` / ``conversations``
+      is a non-empty list.
+    - ``"plain_text"`` : a non-empty string on the ``text`` key.
+    - ``"alpaca"``   : at least one instruction-key and one output-key hit.
+    - ``"unknown"``  : none of the above.
+    """
+    if not isinstance(row, dict):
+        return "unknown"
+    if row.get("conversation_a") is not None and row.get("conversation_b") is not None:
+        return "pairwise"
+    for k in ("messages", "conversation", "conversations"):
+        v = row.get(k)
+        if isinstance(v, list) and v:
+            return "chat"
+    txt = row.get("text")
+    if isinstance(txt, str) and txt.strip():
+        return "plain_text"
+    if any(
+        isinstance(row.get(k), str) and row.get(k, "").strip() for k in instruction_keys
+    ) and any(isinstance(row.get(k), str) and row.get(k, "").strip() for k in output_keys):
+        return "alpaca"
+    return "unknown"
+
+
+def parse_tagged_text(
+    text: str,
+    *,
+    tag_map: dict[str, str] | None = None,
+) -> list[dict[str, str]]:
+    """Parse ``<tag>...<tag>...`` strings into a list of ``{role, content}``.
+
+    ``tag_map`` maps the literal tag token (e.g. ``"usr"``) to the role that
+    should end up in the returned dicts (e.g. ``"user"``). Tags are matched
+    case-insensitively; unknown tags are ignored.
+    """
+    mapping = dict(tag_map or DEFAULT_TAG_MAP)
+    if not mapping:
+        return []
+    alt = "|".join(re.escape(t) for t in mapping)
+    pattern = re.compile(rf"<\s*({alt})\s*>", re.IGNORECASE)
+
+    messages: list[dict[str, str]] = []
+    current_role: str | None = None
+    pos = 0
+    for match in pattern.finditer(text):
+        tag = match.group(1).lower()
+        if current_role is not None:
+            chunk = text[pos : match.start()].strip()
+            if chunk:
+                messages.append({"role": current_role, "content": chunk})
+        current_role = mapping.get(tag)
+        pos = match.end()
+    if current_role is not None:
+        chunk = text[pos:].strip()
+        if chunk:
+            messages.append({"role": current_role, "content": chunk})
+    return messages
+
+
+def unify_messages_dir(
+    src_dir: str | Path,
+    dst_dir: str | Path,
+    *,
+    adapter_kwargs: dict[str, Any] | None = None,
+    sft_strip_metadata: bool = True,
+    sft_strip_keys: Iterable[str] = DEFAULT_SFT_STRIP_KEYS,
+    emit_meta: bool = False,
+) -> tuple[int, int]:
+    """Rewrite every JSONL under ``src_dir`` into a uniform ``{"messages": [...]}`` shape.
+
+    Row-level logic is delegated to :func:`convmerge.adapters.chat.iter_from_chat_line`,
+    so pairwise Arena rows, ``conversation`` / ``conversations`` / ``text``,
+    and alpaca fall-back are all handled identically to the ``chat`` adapter.
+    ``adapter_kwargs`` is forwarded to that function (e.g. ``pairwise_mode``,
+    ``role_map``, custom ``conversation_keys``).
+
+    When ``sft_strip_metadata=True``, any top-level key that is in
+    ``sft_strip_keys`` is stripped on the way out (except ``messages``
+    itself). Supply your own set via ``sft_strip_keys`` to customise.
+
+    Supports in-place rewrites: when ``src_dir`` and ``dst_dir`` resolve to
+    the same absolute path, writes go through a temp directory first and are
+    moved back atomically at the end.
+
+    Returns ``(n_files_written, n_rows_written)``.
+    """
+    adapter_kwargs = dict(adapter_kwargs or {})
+    strip_set = set(sft_strip_keys)
+
+    def _write_row(fout, raw_line: str) -> int:
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError:
+            return 0
+        if not isinstance(obj, dict):
+            return 0
+        n = 0
+        for example in iter_from_chat_line(obj, **adapter_kwargs):
+            out: dict[str, Any] = {
+                "messages": [{"role": m.role, "content": m.content} for m in example.messages]
+            }
+            if emit_meta and example.meta:
+                out["meta"] = dict(example.meta)
+            if sft_strip_metadata:
+                # Propagate non-stripped top-level scalars (e.g. ``id``, ``source``)
+                # that the caller hasn't listed for removal.
+                for k, v in obj.items():
+                    if k == "messages" or k in strip_set:
+                        continue
+                    if k in out:
+                        continue
+                    out[k] = v
+            fout.write(json.dumps(out, ensure_ascii=False) + "\n")
+            n += 1
+        return n
+
+    return _sweep_jsonl_tree(src_dir, dst_dir, _write_row)
+
+
+def unify_message_entries(
+    src_dir: str | Path,
+    dst_dir: str | Path,
+    *,
+    list_key: str = "messages",
+    source_keys: Iterable[str] = ("from",),
+    target_key: str = "role",
+    drop_keys: Iterable[str] = (),
+    require_nonempty_str: bool = True,
+) -> tuple[int, int]:
+    """Normalize the fields inside each entry of a chat-list.
+
+    For every dict inside ``row[list_key]`` (default ``messages``):
+
+    - Remove any key in ``drop_keys``.
+    - Take the value of the first present key in ``source_keys`` and store it
+      under ``target_key`` (e.g. ``from`` -> ``role`` or ``value`` -> ``content``).
+    - Entries where the chosen value is missing or empty are dropped.
+
+    Rows without the ``list_key`` pass through unchanged. Relative paths are
+    preserved and in-place rewrites are supported (temp-dir swap).
+
+    Returns ``(n_files_written, n_rows_written)``.
+    """
+    src_keys_t = tuple(source_keys)
+    drop_set = set(drop_keys)
+
+    def _write_row(fout, raw_line: str) -> int:
+        try:
+            data: dict[str, Any] = json.loads(raw_line)
+        except json.JSONDecodeError:
+            return 0
+        if not isinstance(data, dict):
+            return 0
+
+        items = data.get(list_key)
+        if not isinstance(items, list):
+            fout.write(json.dumps(data, ensure_ascii=False) + "\n")
+            return 1
+
+        new_items: list[dict[str, Any]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            msg = dict(item)
+            for k in drop_set:
+                msg.pop(k, None)
+            chosen: Any = None
+            for sk in src_keys_t:
+                if sk in msg:
+                    chosen = msg.pop(sk)
+                    break
+            if chosen is None:
+                continue
+            if require_nonempty_str and isinstance(chosen, str) and not chosen.strip():
+                continue
+            msg[target_key] = chosen
+            new_items.append(msg)
+        if new_items:
+            data[list_key] = new_items
+        fout.write(json.dumps(data, ensure_ascii=False) + "\n")
+        return 1
+
+    return _sweep_jsonl_tree(src_dir, dst_dir, _write_row)
+
+
+def unify_alpaca_dir(
+    src_dir: str | Path,
+    dst_dir: str | Path,
+    *,
+    instruction_keys: Iterable[str] = DEFAULT_INSTRUCTION_KEYS,
+    output_keys: Iterable[str] = DEFAULT_OUTPUT_KEYS,
+    input_keys: Iterable[str] = DEFAULT_INPUT_KEYS,
+    drop_keys: Iterable[str] = (),
+) -> tuple[int, int]:
+    """Reshape single-turn JSONL trees into the alpaca ``{instruction, input, output}`` form.
+
+    Row-level logic is delegated to
+    :func:`convmerge.adapters.alpaca.remap_to_alpaca`; this function provides
+    the same in-place-safe directory sweep as :func:`unify_messages_dir`.
+    Rows that cannot produce both instruction and output are dropped.
+
+    Returns ``(n_files_written, n_rows_written)``.
+    """
+    instr_t = tuple(instruction_keys)
+    out_t = tuple(output_keys)
+    inp_t = tuple(input_keys)
+    drop_t = tuple(drop_keys)
+
+    def _write_row(fout, raw_line: str) -> int:
+        try:
+            data = json.loads(raw_line)
+        except json.JSONDecodeError:
+            return 0
+        if not isinstance(data, dict):
+            return 0
+        norm = remap_to_alpaca(
+            data,
+            instruction_keys=instr_t,
+            output_keys=out_t,
+            input_keys=inp_t,
+            drop_keys=drop_t,
+        )
+        if norm is None:
+            return 0
+        fout.write(json.dumps(norm, ensure_ascii=False) + "\n")
+        return 1
+
+    return _sweep_jsonl_tree(src_dir, dst_dir, _write_row)
+
+
+def _sweep_jsonl_tree(
+    src_dir: str | Path,
+    dst_dir: str | Path,
+    write_row,
+) -> tuple[int, int]:
+    """Shared driver for the ``unify_*_dir`` helpers.
+
+    Walks ``src_dir`` recursively, opens each ``.jsonl`` file for reading,
+    and passes every raw line to ``write_row(fout, raw_line) -> int``. The
+    callback is expected to write zero or more output rows into ``fout`` and
+    return how many were written (used only for stats).
+
+    Handles the "src == dst" case by writing to a temp directory first.
+    """
+    src_p = Path(src_dir).resolve()
+    dst_p = Path(dst_dir).resolve()
+    if not src_p.is_dir():
+        raise NotADirectoryError(f"Not a directory: {src_p}")
+
+    in_place = src_p == dst_p
+    if in_place:
+        temp_root = Path(tempfile.mkdtemp(prefix="convmerge_reshape_"))
+        actual_dst = temp_root
+    else:
+        temp_root = None
+        actual_dst = dst_p
+        actual_dst.mkdir(parents=True, exist_ok=True)
+
+    try:
+        n_files = 0
+        n_rows = 0
+        for in_path in sorted(src_p.rglob("*.jsonl")):
+            if not in_path.is_file():
+                continue
+            rel = in_path.relative_to(src_p)
+            out_path = actual_dst / rel
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            rows_here = 0
+            with in_path.open(encoding="utf-8") as rf, out_path.open("w", encoding="utf-8") as wf:
+                for raw in rf:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    rows_here += write_row(wf, line)
+            if rows_here:
+                n_files += 1
+                n_rows += rows_here
+            else:
+                # Drop empty output files so the target tree stays clean.
+                try:
+                    out_path.unlink()
+                except OSError:
+                    pass
+
+        if in_place and temp_root is not None:
+            for p in temp_root.rglob("*"):
+                if not p.is_file():
+                    continue
+                rel = p.relative_to(temp_root)
+                final_path = dst_p / rel
+                final_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(p), str(final_path))
+        return n_files, n_rows
+    finally:
+        if temp_root is not None:
+            shutil.rmtree(temp_root, ignore_errors=True)

--- a/src/convmerge/normalize/resume.py
+++ b/src/convmerge/normalize/resume.py
@@ -1,0 +1,98 @@
+"""Resume-safety primitives for append-only JSONL pipelines.
+
+Long-running jobs that append to a JSONL file (e.g. batch inference, chunked
+evaluation) can crash mid-write, leaving a truncated last line. The helpers
+here let resumer code:
+
+1. Count how many rows are currently committed (``count_lines``).
+2. Trim off a corrupt trailing line so the next run re-runs that row from
+   scratch (``trim_corrupt_tail``).
+3. Keep several parallel output files in lockstep by truncating all of them
+   to the same prefix length (``truncate_to_n_lines``).
+
+None of these helpers depend on a particular pipeline or remote service.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def count_lines(path: str | Path) -> int:
+    """Number of ``\\n``-terminated lines in a file. Missing file -> 0."""
+    p = Path(path)
+    if not p.is_file():
+        return 0
+    with p.open(encoding="utf-8") as f:
+        return sum(1 for _ in f)
+
+
+def truncate_to_n_lines(path: str | Path, n: int) -> None:
+    """Keep only the first ``n`` lines of ``path``. ``n == 0`` clears the file.
+
+    Missing file is a no-op. The file is rewritten in full (safe for
+    moderate sizes; not optimised for multi-GB tails).
+    """
+    if n < 0:
+        raise ValueError(f"n must be >= 0, got {n}")
+    p = Path(path)
+    if not p.is_file():
+        return
+    if n == 0:
+        p.write_text("", encoding="utf-8")
+        return
+    with p.open(encoding="utf-8") as f:
+        lines = f.readlines()
+    with p.open("w", encoding="utf-8") as f:
+        f.writelines(lines[:n])
+
+
+def trim_corrupt_tail(
+    path: str | Path,
+    *,
+    companions: tuple[str | Path, ...] = (),
+) -> int:
+    """Drop a truncated JSON line at the end of ``path``.
+
+    Walks the file top-to-bottom, parsing each non-empty line. The first
+    line that fails to parse (and every line after it, if any) is removed.
+    This is the canonical "resume from the last good row" recipe for jobs
+    that append one JSON object per row.
+
+    If ``companions`` are supplied, each of them is truncated to the same
+    line count as ``path`` after the tail is trimmed. This keeps several
+    parallel output files aligned (e.g. a bundle file plus one file per
+    downstream split).
+
+    Returns the number of valid lines retained in ``path``.
+    """
+    p = Path(path)
+    if not p.is_file():
+        return 0
+    with p.open(encoding="utf-8") as f:
+        lines = f.readlines()
+
+    n_raw = len(lines)
+    n_ok = 0
+    for line in lines:
+        s = line.rstrip("\r\n")
+        if not s.strip():
+            # Preserve blank-line accounting as in the raw file.
+            n_ok += 1
+            continue
+        try:
+            json.loads(s)
+        except json.JSONDecodeError:
+            break
+        n_ok += 1
+
+    if n_ok < n_raw:
+        truncate_to_n_lines(p, n_ok)
+
+    for companion in companions:
+        cp = Path(companion)
+        if cp.is_file() and count_lines(cp) > n_ok:
+            truncate_to_n_lines(cp, n_ok)
+
+    return n_ok

--- a/src/convmerge/normalize/sample.py
+++ b/src/convmerge/normalize/sample.py
@@ -1,0 +1,87 @@
+"""Random-sampling utilities for JSONL files.
+
+Two flavours are provided:
+
+- :func:`sample_random` loads every non-blank line into memory and then calls
+  :func:`random.sample`. Simple, deterministic, best when the file fits in RAM.
+- :func:`reservoir_sample` streams the file once, keeping at most ``k`` lines
+  resident. Use this when the source file is larger than available memory.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+
+def sample_random(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    k: int,
+    seed: int = 42,
+) -> tuple[int, int]:
+    """Write ``min(k, n_nonempty)`` random lines from ``src`` to ``dst``.
+
+    Order of lines in ``dst`` follows :func:`random.sample` (pseudo-random).
+    Returns ``(written, total_nonempty)``.
+    """
+    if k < 0:
+        raise ValueError(f"k must be >= 0, got {k}")
+    src_p = Path(src)
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    with src_p.open(encoding="utf-8") as f:
+        lines = [ln for ln in f if ln.strip()]
+    total = len(lines)
+    take = min(k, total)
+
+    rng = random.Random(seed)
+    picked = rng.sample(lines, take) if take else []
+    with dst_p.open("w", encoding="utf-8") as out:
+        for ln in picked:
+            out.write(ln if ln.endswith("\n") else ln + "\n")
+    return take, total
+
+
+def reservoir_sample(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    k: int,
+    seed: int = 42,
+) -> tuple[int, int]:
+    """Streaming reservoir sampler (Algorithm R).
+
+    Suitable for inputs that do not fit in memory: at most ``k`` lines are
+    held resident at any time. Each line of the input is seen exactly once.
+
+    Returns ``(written, total_nonempty)``.
+    """
+    if k < 0:
+        raise ValueError(f"k must be >= 0, got {k}")
+
+    src_p = Path(src)
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    rng = random.Random(seed)
+    reservoir: list[str] = []
+    seen = 0
+    with src_p.open(encoding="utf-8") as f:
+        for raw in f:
+            if not raw.strip():
+                continue
+            if seen < k:
+                reservoir.append(raw)
+            else:
+                j = rng.randrange(seen + 1)
+                if j < k:
+                    reservoir[j] = raw
+            seen += 1
+
+    with dst_p.open("w", encoding="utf-8") as out:
+        for ln in reservoir:
+            out.write(ln if ln.endswith("\n") else ln + "\n")
+    return len(reservoir), seen

--- a/src/convmerge/normalize/split.py
+++ b/src/convmerge/normalize/split.py
@@ -1,0 +1,85 @@
+"""Deterministic train/test split for JSONL files.
+
+Pure Python implementation (no numpy dependency): memory use is dominated by
+a set of up to ``max_samples`` line indices. For typical SFT dataset sizes
+(<=1e7 rows) this is fine; if you have much larger corpora, prefer sharding
++ per-shard splits or supply your own sampler.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+
+def train_test_split(
+    src: str | Path,
+    out_dir: str | Path,
+    *,
+    train_ratio: float = 0.98,
+    seed: int = 42,
+    max_samples: int | None = None,
+    train_name: str = "train.jsonl",
+    test_name: str = "test.jsonl",
+) -> tuple[Path, Path, int, int]:
+    """Shuffle-split a JSONL file into ``train_name`` and ``test_name``.
+
+    Two passes over the file: the first counts non-blank lines, the second
+    streams them back and routes each selected line to the train or test
+    writer. ``max_samples`` sub-samples line indices before the split, which
+    is equivalent to shuffling and truncating the whole dataset.
+
+    ``train_ratio`` must satisfy ``0.0 < train_ratio < 1.0``.
+
+    Returns ``(train_path, test_path, n_train_written, n_test_written)``.
+    """
+    if not 0.0 < train_ratio < 1.0:
+        raise ValueError(f"train_ratio must be in (0,1), got {train_ratio!r}")
+
+    src_p = Path(src)
+    if not src_p.is_file():
+        raise FileNotFoundError(f"No such file: {src_p}")
+
+    with src_p.open(encoding="utf-8") as rf:
+        n_lines = sum(1 for line in rf if line.strip())
+    if n_lines == 0:
+        raise RuntimeError(f"No samples found in {src_p}")
+
+    rng = random.Random(seed)
+    if max_samples is not None and max_samples < n_lines:
+        m = max_samples
+        chosen_indices = rng.sample(range(n_lines), m)
+    else:
+        m = n_lines
+        chosen_indices = list(range(n_lines))
+
+    rng.shuffle(chosen_indices)
+    n_train = int(m * train_ratio)
+    train_set = set(chosen_indices[:n_train])
+    test_set = set(chosen_indices[n_train:])
+
+    out_p = Path(out_dir)
+    out_p.mkdir(parents=True, exist_ok=True)
+    train_path = out_p / train_name
+    test_path = out_p / test_name
+
+    ti = 0
+    written_train = 0
+    written_test = 0
+    with (
+        src_p.open(encoding="utf-8") as rf,
+        train_path.open("w", encoding="utf-8") as wtr,
+        test_path.open("w", encoding="utf-8") as wte,
+    ):
+        for line in rf:
+            if not line.strip():
+                continue
+            if ti in train_set:
+                wtr.write(line if line.endswith("\n") else line + "\n")
+                written_train += 1
+            elif ti in test_set:
+                wte.write(line if line.endswith("\n") else line + "\n")
+                written_test += 1
+            ti += 1
+
+    return train_path, test_path, written_train, written_test

--- a/src/convmerge/normalize/turns.py
+++ b/src/convmerge/normalize/turns.py
@@ -88,3 +88,39 @@ def split_by_turns(
                 mf.write(raw + "\n")
                 m_count += 1
     return s_count, m_count
+
+
+def filter_by_min_turns(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    min_turns: int = 1,
+) -> tuple[int, int]:
+    """Drop samples whose assistant-turn count is below ``min_turns``.
+
+    Streams ``src`` into ``dst`` without loading the whole file. Lines that
+    fail to parse or that do not hold a dict are also dropped. Returns
+    ``(total_rows, kept_rows)`` so callers can log the removal rate.
+    """
+    src_p = Path(src)
+    dst_p = Path(dst)
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+
+    total = 0
+    kept = 0
+    with src_p.open(encoding="utf-8") as rf, dst_p.open("w", encoding="utf-8") as wf:
+        for line in rf:
+            raw = line.strip()
+            if not raw:
+                continue
+            total += 1
+            try:
+                sample = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(sample, dict):
+                continue
+            if count_turns(sample) >= min_turns:
+                wf.write(raw + "\n")
+                kept += 1
+    return total, kept

--- a/src/convmerge/pipeline.py
+++ b/src/convmerge/pipeline.py
@@ -1,0 +1,223 @@
+"""End-to-end dataset-preparation pipeline.
+
+This is a thin orchestrator over the individual primitives in
+:mod:`convmerge.normalize` and :mod:`convmerge.convert`. It intentionally
+has no external dependencies beyond those primitives: no HuggingFace Hub,
+no model inference, no classification / labeling calls. It produces clean
+train/test JSONL on the local filesystem; everything after that (upload,
+labeling, training) lives in your own pipeline.
+
+Typical usage::
+
+    from convmerge.pipeline import build_sft_jsonl
+
+    result = build_sft_jsonl(
+        raw_dir="./raw",
+        out_dir="./out",
+        multi_container_keys=("conversation", "conversations", "text"),
+        alpaca_instruction_keys=("instruction", "question", "prompt"),
+        alpaca_output_keys=("output", "answer", "solution", "completion"),
+        train_ratio=0.98,
+        seed=42,
+    )
+    print(result.train_path, result.test_path)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from convmerge.adapters.chat import DEFAULT_CONVERSATION_KEYS
+from convmerge.convert import convert_dir
+from convmerge.normalize.dedup import deduplicate_jsonl
+from convmerge.normalize.jsonl import normalize_dir, prune_by_suffix
+from convmerge.normalize.merge import collect_jsonl_tree
+from convmerge.normalize.reshape import (
+    DEFAULT_SFT_STRIP_KEYS,
+    unify_alpaca_dir,
+    unify_message_entries,
+    unify_messages_dir,
+)
+from convmerge.normalize.split import train_test_split
+from convmerge.normalize.turns import filter_by_min_turns
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    """Summary returned by :func:`build_sft_jsonl`."""
+
+    jsonl_dir: Path
+    multi_turn_dir: Path
+    single_turn_dir: Path
+    final_dir: Path
+    all_path: Path
+    dedup_path: Path
+    filtered_path: Path
+    train_path: Path
+    test_path: Path
+    counts: dict[str, int] = field(default_factory=dict)
+
+
+def build_sft_jsonl(
+    raw_dir: str | Path,
+    out_dir: str | Path,
+    *,
+    # Intermediate layout (relative to out_dir).
+    jsonl_subdir: str = "jsonl",
+    multi_turn_subdir: str = "multi_turn",
+    single_turn_subdir: str = "single_turn",
+    final_subdir: str = "final",
+    # Junk-file filters applied right after the raw -> jsonl normalize pass.
+    prune_suffixes: Iterable[str] = (),
+    # Schema-hoist keys for chat-style files (conversation -> messages, etc.).
+    multi_container_keys: Iterable[str] = DEFAULT_CONVERSATION_KEYS,
+    # ``from`` -> ``role`` and ``value`` -> ``content`` normalization for ShareGPT-style entries.
+    multi_entry_source_keys: Iterable[str] = ("from", "value"),
+    multi_entry_target_map: dict[str, str] | None = None,
+    # Alpaca-shape sweep (single-turn files).
+    alpaca_instruction_keys: Iterable[str] = ("instruction", "question", "prompt"),
+    alpaca_output_keys: Iterable[str] = ("output", "answer", "solution", "completion"),
+    alpaca_input_keys: Iterable[str] = ("input", "context"),
+    alpaca_drop_keys: Iterable[str] = ("id", "url", "source"),
+    sft_strip_metadata: bool = True,
+    sft_strip_keys: Iterable[str] = DEFAULT_SFT_STRIP_KEYS,
+    # Final-stage knobs.
+    dedupe_algorithm: str = "md5",
+    min_turns: int = 1,
+    train_ratio: float = 0.98,
+    seed: int = 42,
+    max_samples: int | None = None,
+) -> BuildResult:
+    """Run the default SFT prep chain.
+
+    Stages:
+    normalize -> reshape -> convert -> merge -> dedupe -> filter -> split.
+
+    All intermediate directories live under ``out_dir``; no network I/O or
+    model calls are made. The return value points at the final ``train.jsonl``
+    and ``test.jsonl`` plus every intermediate path, so callers can layer
+    their own upload / labeling / training steps on top.
+    """
+    raw_p = Path(raw_dir)
+    out_p = Path(out_dir)
+    out_p.mkdir(parents=True, exist_ok=True)
+
+    jsonl_dir = out_p / jsonl_subdir
+    multi_turn_dir = out_p / multi_turn_subdir
+    single_turn_dir = out_p / single_turn_subdir
+    final_dir = out_p / final_subdir
+    final_dir.mkdir(parents=True, exist_ok=True)
+
+    counts: dict[str, int] = {}
+
+    # 1) Raw -> clean JSONL tree.
+    n_files, n_rows = normalize_dir(raw_p, jsonl_dir)
+    counts["normalize_files"] = n_files
+    counts["normalize_rows"] = n_rows
+
+    # 2) Optional: prune junk files that the source dump ships.
+    if tuple(prune_suffixes):
+        removed = prune_by_suffix(jsonl_dir, prune_suffixes)
+        counts["pruned_files"] = len(removed)
+
+    # 3) Hoist chat-style rows under a single ``messages`` key (keeps pairwise
+    #    winner branch, strips moderation metadata by default).
+    multi_turn_dir.mkdir(parents=True, exist_ok=True)
+    n_mt_files, n_mt_rows = unify_messages_dir(
+        jsonl_dir,
+        multi_turn_dir,
+        adapter_kwargs={
+            "conversation_keys": tuple(multi_container_keys),
+        },
+        sft_strip_metadata=sft_strip_metadata,
+        sft_strip_keys=sft_strip_keys,
+    )
+    counts["multi_turn_files"] = n_mt_files
+    counts["multi_turn_rows"] = n_mt_rows
+
+    # 4) Normalize message entries (from -> role, value -> content, etc.).
+    if multi_entry_target_map:
+        # Apply once per source->target pair; each call rewrites the same tree.
+        for sk, tk in multi_entry_target_map.items():
+            unify_message_entries(
+                multi_turn_dir,
+                multi_turn_dir,
+                source_keys=(sk,),
+                target_key=tk,
+            )
+    else:
+        # Reasonable default: try ``from`` -> ``role`` and ``value`` -> ``content``.
+        unify_message_entries(
+            multi_turn_dir, multi_turn_dir, source_keys=("from",), target_key="role"
+        )
+        unify_message_entries(
+            multi_turn_dir, multi_turn_dir, source_keys=("value",), target_key="content"
+        )
+
+    # 5) Single-turn sweep (alpaca shape) — dropped into its own tree first
+    #    so re-running does not clobber the unified multi_turn tree.
+    single_turn_dir.mkdir(parents=True, exist_ok=True)
+    n_st_files, n_st_rows = unify_alpaca_dir(
+        jsonl_dir,
+        single_turn_dir,
+        instruction_keys=alpaca_instruction_keys,
+        output_keys=alpaca_output_keys,
+        input_keys=alpaca_input_keys,
+        drop_keys=alpaca_drop_keys,
+    )
+    counts["single_turn_files"] = n_st_files
+    counts["single_turn_rows"] = n_st_rows
+
+    # 6) Convert single-turn -> multi-turn ``messages`` shape.
+    n_conv_files, _, n_conv_written = convert_dir(
+        single_turn_dir,
+        multi_turn_dir,
+        adapter_name="alpaca",
+        output_format="messages",
+    )
+    counts["single_to_multi_files"] = n_conv_files
+    counts["single_to_multi_rows"] = n_conv_written
+
+    # 7) Collect everything into a single ``all.jsonl``.
+    all_path = final_dir / "all.jsonl"
+    n_all, n_bad = collect_jsonl_tree([multi_turn_dir], all_path)
+    counts["all_rows"] = n_all
+    counts["all_skipped_bad_json"] = n_bad
+
+    # 8) Dedupe by full-row hash.
+    dedup_path = final_dir / "all_unique.jsonl"
+    n_total, n_kept = deduplicate_jsonl(all_path, dedup_path, algorithm=dedupe_algorithm)
+    counts["dedupe_total"] = n_total
+    counts["dedupe_kept"] = n_kept
+
+    # 9) Filter out rows that don't carry at least ``min_turns`` assistant turns.
+    filtered_path = final_dir / "all_filtered.jsonl"
+    n_total_f, n_kept_f = filter_by_min_turns(dedup_path, filtered_path, min_turns=min_turns)
+    counts["filter_total"] = n_total_f
+    counts["filter_kept"] = n_kept_f
+
+    # 10) Train / test split.
+    train_path, test_path, n_tr, n_te = train_test_split(
+        filtered_path,
+        final_dir,
+        train_ratio=train_ratio,
+        seed=seed,
+        max_samples=max_samples,
+    )
+    counts["train_rows"] = n_tr
+    counts["test_rows"] = n_te
+
+    return BuildResult(
+        jsonl_dir=jsonl_dir,
+        multi_turn_dir=multi_turn_dir,
+        single_turn_dir=single_turn_dir,
+        final_dir=final_dir,
+        all_path=all_path,
+        dedup_path=dedup_path,
+        filtered_path=filtered_path,
+        train_path=train_path,
+        test_path=test_path,
+        counts=counts,
+    )

--- a/tests/test_normalize_merge_split_sample.py
+++ b/tests/test_normalize_merge_split_sample.py
@@ -1,0 +1,126 @@
+"""Tests for merge, split, sample, and resume helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from convmerge.normalize.merge import collect_jsonl_tree, merge_jsonl
+from convmerge.normalize.resume import count_lines, trim_corrupt_tail, truncate_to_n_lines
+from convmerge.normalize.sample import reservoir_sample, sample_random
+from convmerge.normalize.split import train_test_split
+
+
+def test_merge_jsonl_concatenates_and_skips_blank(tmp_path: Path) -> None:
+    a = tmp_path / "a.jsonl"
+    b = tmp_path / "b.jsonl"
+    a.write_text('{"x":1}\n\n{"x":2}\n')
+    b.write_text('{"y":1}\n')
+    out = tmp_path / "merged.jsonl"
+    n = merge_jsonl([a, b], out)
+    assert n == 3
+    assert out.read_text().count("\n") == 3
+
+
+def test_merge_jsonl_validate_drops_junk(tmp_path: Path) -> None:
+    a = tmp_path / "a.jsonl"
+    a.write_text('{"x":1}\nnot json\n{"x":2}\n')
+    out = tmp_path / "merged.jsonl"
+    n = merge_jsonl([a], out, validate=True)
+    assert n == 2
+
+
+def test_merge_jsonl_skips_missing_sources(tmp_path: Path) -> None:
+    real = tmp_path / "real.jsonl"
+    real.write_text('{"x":1}\n')
+    missing = tmp_path / "missing.jsonl"
+    out = tmp_path / "merged.jsonl"
+    n = merge_jsonl([missing, real], out)
+    assert n == 1
+
+
+def test_collect_jsonl_tree_walks_nested(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    (root / "a").mkdir(parents=True)
+    (root / "a" / "1.jsonl").write_text('{"x":1}\n{"bad":\n')  # second line invalid
+    (root / "b.jsonl").write_text('{"y":1}\n{"y":2}\n')
+    out = tmp_path / "all.jsonl"
+    written, skipped = collect_jsonl_tree([root], out)
+    assert written == 3
+    assert skipped == 1
+
+
+def test_train_test_split_deterministic(tmp_path: Path) -> None:
+    src = tmp_path / "src.jsonl"
+    src.write_text("\n".join(json.dumps({"i": i}) for i in range(100)) + "\n")
+    tr, te, n_tr, n_te = train_test_split(src, tmp_path / "out", train_ratio=0.8, seed=42)
+    assert n_tr + n_te == 100
+    assert abs(n_tr - 80) <= 1
+    tr2, te2, _, _ = train_test_split(src, tmp_path / "out2", train_ratio=0.8, seed=42)
+    assert tr.read_text() == tr2.read_text()
+    assert te.read_text() == te2.read_text()
+
+
+def test_train_test_split_with_max_samples(tmp_path: Path) -> None:
+    src = tmp_path / "src.jsonl"
+    src.write_text("\n".join(json.dumps({"i": i}) for i in range(100)) + "\n")
+    _, _, n_tr, n_te = train_test_split(
+        src, tmp_path / "out", train_ratio=0.8, seed=1, max_samples=20
+    )
+    assert n_tr + n_te == 20
+
+
+def test_sample_random_returns_k_lines(tmp_path: Path) -> None:
+    src = tmp_path / "src.jsonl"
+    src.write_text("\n".join(str(i) for i in range(50)) + "\n")
+    dst = tmp_path / "s.jsonl"
+    written, total = sample_random(src, dst, k=10, seed=3)
+    assert total == 50
+    assert written == 10
+    assert dst.read_text().count("\n") == 10
+
+
+def test_sample_random_k_larger_than_population(tmp_path: Path) -> None:
+    src = tmp_path / "src.jsonl"
+    src.write_text("a\nb\n")
+    dst = tmp_path / "s.jsonl"
+    written, total = sample_random(src, dst, k=10)
+    assert total == 2
+    assert written == 2
+
+
+def test_reservoir_sample_bounded(tmp_path: Path) -> None:
+    src = tmp_path / "src.jsonl"
+    src.write_text("\n".join(str(i) for i in range(1000)) + "\n")
+    dst = tmp_path / "s.jsonl"
+    written, seen = reservoir_sample(src, dst, k=25, seed=9)
+    assert written == 25
+    assert seen == 1000
+
+
+def test_trim_corrupt_tail_and_companions(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle.jsonl"
+    split1 = tmp_path / "split1.jsonl"
+    split2 = tmp_path / "split2.jsonl"
+    bundle.write_text('{"ok":1}\n{"ok":2}\n{broken')
+    split1.write_text("a\nb\nc\n")
+    split2.write_text("a\nb\nc\n")
+
+    n = trim_corrupt_tail(bundle, companions=(split1, split2))
+    assert n == 2
+    assert count_lines(bundle) == 2
+    assert count_lines(split1) == 2
+    assert count_lines(split2) == 2
+
+
+def test_truncate_to_n_lines(tmp_path: Path) -> None:
+    p = tmp_path / "p.jsonl"
+    p.write_text("a\nb\nc\nd\n")
+    truncate_to_n_lines(p, 2)
+    assert p.read_text() == "a\nb\n"
+    truncate_to_n_lines(p, 0)
+    assert p.read_text() == ""
+
+
+def test_count_lines_missing_file(tmp_path: Path) -> None:
+    assert count_lines(tmp_path / "nope.jsonl") == 0

--- a/tests/test_normalize_primitives.py
+++ b/tests/test_normalize_primitives.py
@@ -1,0 +1,103 @@
+"""Tests for the directory-level primitives added to convmerge.normalize."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from convmerge.normalize import (
+    head_preview,
+    head_preview_dir,
+    normalize_dir,
+    prune_by_suffix,
+    scan_shapes,
+)
+from convmerge.normalize.turns import filter_by_min_turns
+
+
+def test_normalize_dir_walks_json_and_jsonl(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.json").write_text('[{"x":1},{"x":2}]')
+    (src / "sub").mkdir()
+    (src / "sub" / "b.jsonl").write_text('{"y":1}{"y":2}{"y":3}')
+    dst = tmp_path / "dst"
+
+    n_files, n_rows = normalize_dir(src, dst)
+
+    assert n_files == 2
+    assert n_rows == 5
+    assert (dst / "a.jsonl").read_text().count("\n") == 2
+    assert (dst / "sub" / "b.jsonl").read_text().count("\n") == 3
+
+
+def test_normalize_dir_skips_non_matching(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "README.md").write_text("skip me")
+    (src / "a.jsonl").write_text('{"x":1}\n')
+    dst = tmp_path / "dst"
+
+    n_files, n_rows = normalize_dir(src, dst)
+    assert n_files == 1
+    assert n_rows == 1
+    assert not (dst / "README.md").exists()
+
+
+def test_prune_by_suffix_removes_matches(tmp_path: Path) -> None:
+    (tmp_path / "a-res.jsonl").write_text("x")
+    (tmp_path / "b.jsonl").write_text("x")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c-res.jsonl").write_text("x")
+
+    removed = prune_by_suffix(tmp_path, ["-res.jsonl"])
+    names = {p.name for p in removed}
+    assert names == {"a-res.jsonl", "c-res.jsonl"}
+    assert not (tmp_path / "a-res.jsonl").exists()
+    assert (tmp_path / "b.jsonl").exists()
+
+
+def test_prune_by_suffix_dry_run(tmp_path: Path) -> None:
+    (tmp_path / "a-res.jsonl").write_text("x")
+    removed = prune_by_suffix(tmp_path, ["-res.jsonl"], dry_run=True)
+    assert len(removed) == 1
+    assert (tmp_path / "a-res.jsonl").exists()
+
+
+def test_head_preview_returns_first_line(tmp_path: Path) -> None:
+    p = tmp_path / "a.jsonl"
+    p.write_text('{"x":1}\n{"x":2}\n')
+    assert head_preview(p) == '{"x":1}'
+
+
+def test_head_preview_dir_filters_by_extension(tmp_path: Path) -> None:
+    (tmp_path / "a.jsonl").write_text('{"x":1}\n')
+    (tmp_path / "b.md").write_text("not me")
+    previews = head_preview_dir(tmp_path, extensions=[".jsonl"])
+    assert len(previews) == 1
+    assert list(previews.values())[0] == '{"x":1}'
+
+
+def test_scan_shapes_classifies_each_file(tmp_path: Path) -> None:
+    (tmp_path / "a.jsonl").write_text('{"x":1}\n{"x":2}\n')
+    (tmp_path / "b.json").write_text('[{"x":1}]')
+    (tmp_path / "c.jsonl").write_text('{"x":1}{"x":2}')
+    shapes = scan_shapes(tmp_path)
+    mapped = {p.name: s for p, s in shapes.items()}
+    assert mapped == {"a.jsonl": "jsonl", "b.json": "json_array", "c.jsonl": "single_line"}
+
+
+def test_filter_by_min_turns_drops_short_rows(tmp_path: Path) -> None:
+    src = tmp_path / "src.jsonl"
+    dst = tmp_path / "dst.jsonl"
+    rows = [
+        {"messages": [{"role": "user", "content": "hi"}]},
+        {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hey"}]},
+    ]
+    src.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    total, kept = filter_by_min_turns(src, dst, min_turns=1)
+    assert total == 2
+    assert kept == 1
+    assert dst.read_text().strip().count("\n") == 0

--- a/tests/test_normalize_reshape.py
+++ b/tests/test_normalize_reshape.py
@@ -1,0 +1,136 @@
+"""Tests for convmerge.normalize.reshape and the alpaca remap helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from convmerge.adapters.alpaca import remap_to_alpaca
+from convmerge.normalize.reshape import (
+    classify_row_shape,
+    parse_tagged_text,
+    unify_alpaca_dir,
+    unify_message_entries,
+    unify_messages_dir,
+)
+
+
+def test_classify_row_shape_variants() -> None:
+    assert classify_row_shape({"messages": [{"role": "user", "content": "x"}]}) == "chat"
+    assert (
+        classify_row_shape({"conversation_a": [{"role": "user"}], "conversation_b": []})
+        == "pairwise"
+    )
+    assert classify_row_shape({"instruction": "a", "output": "b"}) == "alpaca"
+    assert classify_row_shape({"text": "just text"}) == "plain_text"
+    assert classify_row_shape({"misc": 1}) == "unknown"
+
+
+def test_parse_tagged_text_default_map() -> None:
+    msgs = parse_tagged_text("<sys>be nice<usr>hi<bot>hello")
+    assert msgs == [
+        {"role": "system", "content": "be nice"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+
+def test_parse_tagged_text_custom_map() -> None:
+    msgs = parse_tagged_text("<H>hi<A>hey", tag_map={"h": "user", "a": "assistant"})
+    assert msgs == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hey"},
+    ]
+
+
+def test_remap_to_alpaca_picks_first_hit() -> None:
+    out = remap_to_alpaca(
+        {"question": "q", "answer": "a", "meta": "drop", "input": "ctx"},
+        drop_keys=("meta",),
+    )
+    assert out == {"instruction": "q", "input": "ctx", "output": "a"}
+
+
+def test_remap_to_alpaca_returns_none_when_incomplete() -> None:
+    assert remap_to_alpaca({"question": "only q"}) is None
+
+
+def test_unify_messages_dir_hoists_conversations(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.jsonl").write_text(
+        json.dumps(
+            {
+                "conversation": [
+                    {"from": "human", "value": "q"},
+                    {"from": "gpt", "value": "a"},
+                ]
+            }
+        )
+        + "\n"
+    )
+    dst = tmp_path / "dst"
+    n_files, n_rows = unify_messages_dir(src, dst)
+    assert n_files == 1
+    assert n_rows == 1
+    obj = json.loads((dst / "a.jsonl").read_text())
+    assert obj["messages"] == [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+    ]
+
+
+def test_unify_messages_dir_in_place(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.jsonl").write_text(
+        json.dumps({"messages": [{"role": "user", "content": "q"}]}) + "\n"
+    )
+    n_files, _ = unify_messages_dir(src, src)
+    assert n_files == 1
+    obj = json.loads((src / "a.jsonl").read_text())
+    assert obj["messages"] == [{"role": "user", "content": "q"}]
+
+
+def test_unify_message_entries_maps_from_to_role(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.jsonl").write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"from": "human", "content": "q"},
+                    {"from": "gpt", "content": "a"},
+                ]
+            }
+        )
+        + "\n"
+    )
+    dst = tmp_path / "dst"
+    unify_message_entries(src, dst, source_keys=("from",), target_key="role")
+    obj = json.loads((dst / "a.jsonl").read_text())
+    assert obj["messages"] == [
+        {"role": "human", "content": "q"},
+        {"role": "gpt", "content": "a"},
+    ]
+
+
+def test_unify_alpaca_dir_writes_standard_schema(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.jsonl").write_text(
+        json.dumps({"prompt": "q1", "response": "a1", "id": "drop-me"})
+        + "\n"
+        + json.dumps({"missing": "instr"})
+        + "\n"
+    )
+    dst = tmp_path / "dst"
+    n_files, n_rows = unify_alpaca_dir(
+        src,
+        dst,
+        drop_keys=("id",),
+    )
+    assert n_files == 1
+    assert n_rows == 1
+    obj = json.loads((dst / "a.jsonl").read_text().strip())
+    assert obj == {"instruction": "q1", "input": "", "output": "a1"}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,72 @@
+"""Integration tests for convmerge.pipeline.build_sft_jsonl and convert_dir."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from convmerge.convert import convert_dir
+from convmerge.pipeline import build_sft_jsonl
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+
+def test_convert_dir_preserves_tree(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    (src / "sub").mkdir(parents=True)
+    _write_jsonl(
+        src / "sub" / "a.jsonl",
+        [{"instruction": "q1", "output": "a1"}, {"instruction": "q2", "output": "a2"}],
+    )
+    dst = tmp_path / "dst"
+
+    n_files, n_in, n_out = convert_dir(src, dst, adapter_name="alpaca", output_format="messages")
+    assert n_files == 1
+    assert n_in == 2
+    assert n_out == 2
+
+    out = (dst / "sub" / "a.jsonl").read_text().splitlines()
+    assert len(out) == 2
+    first = json.loads(out[0])
+    assert "messages" in first
+    assert first["messages"][0]["role"] == "user"
+
+
+def test_build_sft_jsonl_end_to_end(tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    # Alpaca-style JSON array
+    (raw / "alpaca.json").write_text(
+        json.dumps([{"instruction": f"q{i}", "output": f"a{i}"} for i in range(20)])
+    )
+    # ShareGPT-style JSONL
+    sharegpt_rows = [
+        {
+            "messages": [
+                {"role": "user", "content": f"hello {i}"},
+                {"role": "assistant", "content": f"hi {i}"},
+            ]
+        }
+        for i in range(20)
+    ]
+    _write_jsonl(raw / "chat.jsonl", sharegpt_rows)
+
+    out = tmp_path / "out"
+    result = build_sft_jsonl(raw, out, train_ratio=0.8, seed=123, min_turns=1)
+
+    assert result.counts["normalize_files"] == 2
+    assert result.counts["normalize_rows"] == 40
+    assert result.train_path.exists()
+    assert result.test_path.exists()
+    # Total = train + test <= 40 (after dedupe / filter).
+    train_lines = result.train_path.read_text().strip().splitlines()
+    test_lines = result.test_path.read_text().strip().splitlines()
+    assert len(train_lines) + len(test_lines) == result.counts["filter_kept"]
+    # Every output row should be messages-shaped.
+    for ln in train_lines + test_lines:
+        obj = json.loads(ln)
+        assert "messages" in obj
+        assert isinstance(obj["messages"], list)


### PR DESCRIPTION
## Summary

- Directory-level primitives (`normalize_dir`, `prune_by_suffix`, `head_preview_dir`, `scan_shapes`) + schema-unification sweeps (`unify_messages_dir`, `unify_message_entries`, `unify_alpaca_dir`, `parse_tagged_text`) so downstream notebooks / scripts can drop hand-rolled SFT prep code.
- New `convmerge.normalize` modules: `merge` (`merge_jsonl`, `collect_jsonl_tree`), `split` (`train_test_split`), `sample` (`sample_random`, `reservoir_sample`), `resume` (`count_lines`, `truncate_to_n_lines`, `trim_corrupt_tail` with `companions=`). Core stays dependency-free (pure-Python random; no numpy in the core path).
- `convmerge.pipeline.build_sft_jsonl`: one-call orchestration of normalize → reshape → convert → merge → dedupe → filter → split, returning every intermediate path via `BuildResult`.
- Adapters: `remap_to_alpaca` promoted to public API; chat adapter delegates to it. `convert.convert_dir` walks trees, preserving layout.
- CLI: `merge`, `split`, `sample`, `build` subcommands.
- Docs: expanded **Out of scope** (HF Hub upload, RunPod/Anthropic batch, tokenizer-aware filtering, product-specific transforms); [docs/migration-0.3.md](docs/migration-0.3.md) maps legacy notebook helpers → convmerge APIs. Example recipe under `examples/recipes/build_sft_from_mixed_jsonl.py`.

## Scope decisions

- No numpy in the core train/test split; users with >1e7 rows should shard.
- Nothing that touches a network, a model, or a product-specific transform ships here. Those stay in the caller.

## Test plan

- [x] `ruff check` + `ruff format --check` clean (52 files).
- [x] `pytest -q` passes: **118/118** (+31 new tests across primitives, merge/split/sample, reshape, pipeline).
- [x] End-to-end smoke: `build_sft_jsonl` run on a mixed raw/ tree (parquet + json array + messages jsonl + sharegpt) produces the expected train/test split and the pipeline intermediate tree.
- [x] Downstream notebook refactor (`Neura_Data/notebooks/{filter,refine}.ipynb`) compiles and binds every new symbol it imports.