### PR TITLE
fix: sanitize JSONL lines during normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalize JSONL inputs with a leading UTF-8 BOM, CRLF line endings, and trailing whitespace; report trailing-comma JSONL lines with file and line context.
+
 ## [0.3.3] - 2026-04-23
 
 ### Added

--- a/src/convmerge/normalize/jsonl.py
+++ b/src/convmerge/normalize/jsonl.py
@@ -157,15 +157,27 @@ def normalize_to_jsonl(src: str | Path, dst: str | Path) -> int:
 def _rewrite_jsonl(src: Path, dst: Path) -> int:
     n = 0
     with src.open(encoding="utf-8") as fin, dst.open("w", encoding="utf-8") as fout:
-        for line in fin:
-            line = line.strip()
+        for line_number, line in enumerate(fin, 1):
+            line = _sanitize_line(line, line_number=line_number)
             if not line:
                 continue
+            if line.endswith(","):
+                raise ValueError(
+                    f"Cannot normalize {src}: trailing comma at line {line_number}; "
+                    "remove the comma or provide valid JSONL"
+                )
             # Validate each line so the output is guaranteed to round-trip.
             json.loads(line)
             fout.write(line + "\n")
             n += 1
     return n
+
+
+def _sanitize_line(line: str, *, line_number: int) -> str:
+    line = line.rstrip()
+    if line_number == 1:
+        line = line.removeprefix("\ufeff")
+    return line
 
 
 def _rewrite_json_array(src: Path, dst: Path) -> int:

--- a/tests/test_normalize_jsonl.py
+++ b/tests/test_normalize_jsonl.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from convmerge.normalize.jsonl import (
     detect_jsonl_shape,
     iter_json_records,
@@ -81,3 +83,26 @@ def test_iter_json_records_handles_json_single_object(tmp_path: Path) -> None:
 def test_iter_json_records_max_rows(tmp_path: Path) -> None:
     p = _write(tmp_path / "a.jsonl", '{"x":1}\n{"x":2}\n{"x":3}\n')
     assert list(iter_json_records(p, max_rows=2)) == [{"x": 1}, {"x": 2}]
+
+
+def test_normalize_jsonl_sanitizes_bom_crlf_and_trailing_whitespace(tmp_path: Path) -> None:
+    src = _write(tmp_path / "messy.jsonl", '\ufeff{"x":1}   \r\n{"x":2}\t \r\n')
+    dst = tmp_path / "out.jsonl"
+
+    n = normalize_to_jsonl(src, dst)
+
+    assert n == 2
+    assert dst.read_text(encoding="utf-8") == '{"x":1}\n{"x":2}\n'
+
+
+def test_normalize_jsonl_rejects_trailing_comma_with_file_and_line(tmp_path: Path) -> None:
+    src = _write(tmp_path / "bad.jsonl", '{"x":1},\n{"x":2}\n')
+    dst = tmp_path / "out.jsonl"
+
+    with pytest.raises(ValueError) as exc_info:
+        normalize_to_jsonl(src, dst)
+
+    message = str(exc_info.value)
+    assert "bad.jsonl" in message
+    assert "line 1" in message
+    assert "trailing comma" in message


### PR DESCRIPTION
## Summary

Fixes #9.

This updates JSONL normalization to handle a few common real-world line variants before validating/writing output:

- strips a leading UTF-8 BOM from the first JSONL line
- trims trailing whitespace, including CRLF-authored lines
- rejects trailing-comma JSONL lines with a `ValueError` that includes the source file and line number
- adds regression coverage and an Unreleased changelog entry

## Checklist

- [x] `ruff check src tests` and `ruff format --check src tests` pass
- [x] `pytest -q` passes
- [x] Tests added or updated for behaviour changes
- [x] Docs updated if adapters / emitters / CLI changed (`README.md`, `docs/format.md`, `docs/fetch.md`)
- [x] `CHANGELOG.md` entry added under `## [Unreleased]`
- [x] Change fits the project scope (see README "Out of scope" and `CONTRIBUTING.md` "What we want / don't want")

## Related issue

Closes #9
