### PR TITLE
feat: weighted mix command for domain-controlled dataset merging

### DIFF
--- a/src/convmerge/cli.py
+++ b/src/convmerge/cli.py
@@ -42,6 +42,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_turns(args)
     elif args.command == "fetch":
         _cmd_fetch(args)
+    elif args.command == "mix":
+        _cmd_mix(args)
     else:  # pragma: no cover - argparse enforces ``required=True``
         parser.error(f"unknown command: {args.command}")
 
@@ -65,6 +67,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_turns(subparsers)
     _add_fetch(subparsers)
     _add_preset(subparsers)
+    _add_mix(subparsers)
 
     return parser
 
@@ -454,6 +457,116 @@ def _with_overridden_defaults(manifest, *, on_error, resume):
     if resume is not None:
         new_defaults = replace(new_defaults, resume=resume)
     return replace(manifest, defaults=new_defaults)
+
+
+def _add_mix(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "mix",
+        help=(
+            "Sample from multiple converted JSONL sources at specified weights "
+            "and merge into one file (install convmerge[preset] for YAML configs)"
+        ),
+    )
+    p.add_argument(
+        "config",
+        nargs="?",
+        default=None,
+        metavar="CONFIG",
+        help="Path to a YAML or JSON mix config file",
+    )
+    p.add_argument(
+        "--input",
+        "-i",
+        nargs="+",
+        metavar="FILE:WEIGHT",
+        default=None,
+        help="Inline sources as path:weight pairs, e.g. code.jsonl:0.4 math.jsonl:0.6",
+    )
+    p.add_argument("--output", "-o", type=Path, default=None, help="Output JSONL path")
+    p.add_argument("--total", "-n", type=int, default=None, help="Target total record count")
+    p.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    p.add_argument(
+        "--oversample",
+        action="store_true",
+        help="Allow sampling with replacement when a source has fewer records than requested",
+    )
+    p.add_argument(
+        "--no-recipe",
+        action="store_true",
+        help="Skip writing the .mix.json sidecar file",
+    )
+    p.add_argument("--encoding", default="utf-8")
+
+
+def _cmd_mix(args: argparse.Namespace) -> None:
+    from convmerge.mix import MixSource, load_mix_config, mix_files, write_mix_recipe
+
+    sources: list[MixSource] = []
+    options: dict = {}
+
+    if args.config:
+        config_path = Path(args.config)
+        if not config_path.is_file():
+            print(f"error: config file not found: {config_path}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            sources, options = load_mix_config(config_path)
+        except (ValueError, ImportError, OSError) as e:
+            print(f"error: {e}", file=sys.stderr)
+            sys.exit(2)
+    elif args.input:
+        for spec in args.input:
+            try:
+                file_part, weight_part = spec.rsplit(":", 1)
+                sources.append(MixSource(Path(file_part), float(weight_part)))
+            except ValueError:
+                print(
+                    f"error: invalid source spec {spec!r}. Expected FILE:WEIGHT",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+    else:
+        print(
+            "error: provide a config file or --input FILE:WEIGHT pairs",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # CLI flags override config file values
+    output = args.output or options.get("output")
+    total = args.total if args.total is not None else options.get("total")
+    seed = args.seed if args.seed != 42 or "seed" not in options else options["seed"]
+    oversample = args.oversample or options.get("oversample", False)
+
+    if output is None:
+        print("error: --output / -o is required (or set 'output' in config)", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        result = mix_files(
+            sources,
+            output,
+            total=total,
+            seed=seed,
+            oversample=oversample,
+            encoding=args.encoding,
+        )
+    except (FileNotFoundError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    for s in result.sources:
+        clipped = s.available < s.requested and not oversample
+        note = f" (clipped from {s.requested:,})" if clipped else ""
+        print(
+            f"  {s.path}: weight={s.weight:.4f} written={s.written:,}{note}",
+            file=sys.stderr,
+        )
+    print(f"total written: {result.total_written:,} -> {result.output}", file=sys.stderr)
+
+    if not args.no_recipe:
+        sidecar = write_mix_recipe(result, encoding=args.encoding)
+        print(f"recipe:        {sidecar}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/src/convmerge/mix.py
+++ b/src/convmerge/mix.py
@@ -1,0 +1,218 @@
+"""Weighted mixing of multiple converted JSONL sources into one merged file."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MixSource:
+    """One source entry: a JSONL file and its sampling weight."""
+
+    path: Path
+    weight: float
+
+
+@dataclass
+class SourceStats:
+    path: Path
+    weight: float
+    requested: int
+    available: int
+    written: int
+
+
+@dataclass
+class MixResult:
+    total_written: int
+    seed: int
+    output: Path
+    sources: list[SourceStats] = field(default_factory=list)
+
+
+def mix_files(
+    sources: list[MixSource],
+    output_path: Path,
+    *,
+    total: int | None = None,
+    seed: int = 42,
+    oversample: bool = False,
+    encoding: str = "utf-8",
+) -> MixResult:
+    """Sample from each source at its weight and write a merged JSONL file.
+
+    When *total* is None all records are merged (weights are ignored for
+    sampling; the result is just a seeded shuffle of the concatenation).
+    When a source has fewer records than requested and *oversample* is False
+    the source is clipped to its full size; set *oversample=True* to allow
+    sampling with replacement.
+
+    Weights are automatically normalized so they need not sum to 1.0.
+
+    Returns a :class:`MixResult` with per-source statistics.
+    """
+    if not sources:
+        raise ValueError("At least one source is required")
+
+    total_weight = sum(s.weight for s in sources)
+    if total_weight <= 0:
+        raise ValueError("Weights must be positive")
+
+    normalized = [MixSource(s.path, s.weight / total_weight) for s in sources]
+
+    loaded: list[list[str]] = []
+    for src in normalized:
+        if not src.path.is_file():
+            raise FileNotFoundError(f"Source not found: {src.path}")
+        loaded.append(_load_valid_lines(src.path, encoding))
+
+    if total is None:
+        targets = [len(recs) for recs in loaded]
+    else:
+        targets = _allocate(normalized, total)
+
+    rng = random.Random(seed)
+    sampled: list[list[str]] = []
+    stats: list[SourceStats] = []
+
+    for src, recs, target in zip(normalized, loaded, targets):
+        available = len(recs)
+        if available == 0:
+            sampled.append([])
+            stats.append(SourceStats(src.path, src.weight, target, 0, 0))
+            continue
+        if target <= available:
+            chosen = rng.sample(recs, target)
+        elif oversample:
+            chosen = rng.choices(recs, k=target)
+        else:
+            chosen = list(recs)
+        sampled.append(chosen)
+        stats.append(SourceStats(src.path, src.weight, target, available, len(chosen)))
+
+    all_records = [line for group in sampled for line in group]
+    rng.shuffle(all_records)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding=encoding) as f:
+        for line in all_records:
+            f.write(line + "\n")
+
+    return MixResult(
+        total_written=len(all_records),
+        seed=seed,
+        output=output_path,
+        sources=stats,
+    )
+
+
+def write_mix_recipe(result: MixResult, *, encoding: str = "utf-8") -> Path:
+    """Write a sidecar <output>.mix.json recording the exact mix parameters.
+
+    The file can be used to audit or replay the mix run.
+    """
+    import datetime
+
+    recipe = {
+        "version": 1,
+        "seed": result.seed,
+        "total_written": result.total_written,
+        "output": str(result.output),
+        "sources": [
+            {
+                "path": str(s.path),
+                "weight": s.weight,
+                "requested": s.requested,
+                "available": s.available,
+                "written": s.written,
+            }
+            for s in result.sources
+        ],
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    sidecar = result.output.with_suffix(".mix.json")
+    sidecar.write_text(json.dumps(recipe, indent=2, ensure_ascii=False), encoding=encoding)
+    return sidecar
+
+
+def load_mix_config(path: Path) -> tuple[list[MixSource], dict]:
+    """Parse a YAML or JSON mix config file.
+
+    Returns ``(sources, options)`` where *options* may contain
+    ``total``, ``seed``, ``output``, and ``oversample``.
+
+    YAML support requires ``pyyaml`` (``pip install 'convmerge[preset]'``).
+    """
+    suffix = path.suffix.lower()
+    text = path.read_text(encoding="utf-8")
+
+    if suffix in (".yaml", ".yml"):
+        try:
+            import yaml
+        except ImportError as e:
+            raise ImportError(
+                "pyyaml is required for YAML mix configs. "
+                "Install with: pip install 'convmerge[preset]'"
+            ) from e
+        raw = yaml.safe_load(text) or {}
+    else:
+        raw = json.loads(text)
+
+    if not isinstance(raw, dict):
+        raise ValueError("Mix config root must be a mapping")
+
+    entries_raw = raw.get("sources") or []
+    if not isinstance(entries_raw, list) or not entries_raw:
+        raise ValueError("Mix config must have a non-empty 'sources' list")
+
+    sources: list[MixSource] = []
+    for i, item in enumerate(entries_raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"sources[{i}] must be a mapping")
+        p = item.get("path")
+        w = item.get("weight")
+        if not p:
+            raise ValueError(f"sources[{i}].path is required")
+        if w is None:
+            raise ValueError(f"sources[{i}].weight is required")
+        sources.append(MixSource(Path(p), float(w)))
+
+    options: dict = {}
+    if "total" in raw:
+        options["total"] = int(raw["total"])
+    if "seed" in raw:
+        options["seed"] = int(raw["seed"])
+    if "output" in raw:
+        options["output"] = Path(raw["output"])
+    if "oversample" in raw:
+        options["oversample"] = bool(raw["oversample"])
+
+    return sources, options
+
+
+def _load_valid_lines(path: Path, encoding: str) -> list[str]:
+    lines = []
+    with path.open(encoding=encoding) as f:
+        for raw in f:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            lines.append(stripped)
+    return lines
+
+
+def _allocate(sources: list[MixSource], total: int) -> list[int]:
+    """Distribute *total* across sources by weight, correcting rounding error."""
+    counts = [round(total * s.weight) for s in sources]
+    diff = total - sum(counts)
+    if diff != 0:
+        idx = max(range(len(counts)), key=lambda i: counts[i])
+        counts[idx] += diff
+    return counts

--- a/tests/test_mix.py
+++ b/tests/test_mix.py
@@ -1,0 +1,355 @@
+"""Tests for convmerge.mix and the ``mix`` CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from convmerge.mix import MixSource, _allocate, load_mix_config, mix_files, write_mix_recipe
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_jsonl(path: Path, records: list[dict]) -> None:
+    with path.open("w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# _allocate
+# ---------------------------------------------------------------------------
+
+
+def test_allocate_exact():
+    sources = [MixSource(Path("a"), 0.6), MixSource(Path("b"), 0.4)]
+    counts = _allocate(sources, 100)
+    assert counts == [60, 40]
+    assert sum(counts) == 100
+
+
+def test_allocate_rounding_corrected():
+    sources = [MixSource(Path("a"), 1 / 3), MixSource(Path("b"), 1 / 3), MixSource(Path("c"), 1 / 3)]
+    counts = _allocate(sources, 100)
+    assert sum(counts) == 100
+
+
+def test_allocate_single_source():
+    sources = [MixSource(Path("a"), 1.0)]
+    assert _allocate(sources, 77) == [77]
+
+
+# ---------------------------------------------------------------------------
+# mix_files — basic behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_basic_mix(tmp_path):
+    src_a = tmp_path / "a.jsonl"
+    src_b = tmp_path / "b.jsonl"
+    write_jsonl(src_a, [{"src": "a", "i": i} for i in range(100)])
+    write_jsonl(src_b, [{"src": "b", "i": i} for i in range(100)])
+
+    out = tmp_path / "mixed.jsonl"
+    result = mix_files([MixSource(src_a, 0.6), MixSource(src_b, 0.4)], out, total=100, seed=42)
+
+    assert result.total_written == 100
+    lines = read_jsonl(out)
+    assert len(lines) == 100
+    srcs = [r["src"] for r in lines]
+    assert srcs.count("a") == 60
+    assert srcs.count("b") == 40
+
+
+def test_no_total_merges_all(tmp_path):
+    src_a = tmp_path / "a.jsonl"
+    src_b = tmp_path / "b.jsonl"
+    write_jsonl(src_a, [{"x": i} for i in range(30)])
+    write_jsonl(src_b, [{"x": i} for i in range(20)])
+
+    out = tmp_path / "out.jsonl"
+    result = mix_files([MixSource(src_a, 0.5), MixSource(src_b, 0.5)], out, seed=42)
+
+    assert result.total_written == 50
+    assert len(read_jsonl(out)) == 50
+
+
+def test_weight_normalization(tmp_path):
+    """Weights 2:1 should behave identically to 0.667:0.333."""
+    src_a = tmp_path / "a.jsonl"
+    src_b = tmp_path / "b.jsonl"
+    write_jsonl(src_a, [{"x": i} for i in range(1000)])
+    write_jsonl(src_b, [{"x": i} for i in range(1000)])
+
+    out = tmp_path / "out.jsonl"
+    result = mix_files([MixSource(src_a, 2.0), MixSource(src_b, 1.0)], out, total=99, seed=42)
+
+    assert result.total_written == 99
+    assert result.sources[0].written == 66
+    assert result.sources[1].written == 33
+
+
+# ---------------------------------------------------------------------------
+# mix_files — reproducibility
+# ---------------------------------------------------------------------------
+
+
+def test_same_seed_same_output(tmp_path):
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": i} for i in range(1000)])
+
+    out1 = tmp_path / "out1.jsonl"
+    out2 = tmp_path / "out2.jsonl"
+    mix_files([MixSource(src, 1.0)], out1, total=200, seed=7)
+    mix_files([MixSource(src, 1.0)], out2, total=200, seed=7)
+
+    assert out1.read_text() == out2.read_text()
+
+
+def test_different_seeds_different_output(tmp_path):
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": i} for i in range(1000)])
+
+    out1 = tmp_path / "out1.jsonl"
+    out2 = tmp_path / "out2.jsonl"
+    mix_files([MixSource(src, 1.0)], out1, total=200, seed=1)
+    mix_files([MixSource(src, 1.0)], out2, total=200, seed=2)
+
+    assert out1.read_text() != out2.read_text()
+
+
+# ---------------------------------------------------------------------------
+# mix_files — clip and oversample
+# ---------------------------------------------------------------------------
+
+
+def test_clip_when_source_too_small(tmp_path):
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": i} for i in range(10)])
+
+    out = tmp_path / "out.jsonl"
+    result = mix_files([MixSource(src, 1.0)], out, total=100, seed=42)
+
+    assert result.total_written == 10
+    assert result.sources[0].written == 10
+    assert result.sources[0].requested == 100
+    assert result.sources[0].available == 10
+
+
+def test_oversample(tmp_path):
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": i} for i in range(10)])
+
+    out = tmp_path / "out.jsonl"
+    result = mix_files([MixSource(src, 1.0)], out, total=50, seed=42, oversample=True)
+
+    assert result.total_written == 50
+    assert len(read_jsonl(out)) == 50
+
+
+def test_empty_source_skipped(tmp_path):
+    """Empty source contributes 0; its budget is not redistributed to others."""
+    src_empty = tmp_path / "empty.jsonl"
+    src_empty.write_text("")
+    src_ok = tmp_path / "ok.jsonl"
+    write_jsonl(src_ok, [{"x": i} for i in range(50)])
+
+    out = tmp_path / "out.jsonl"
+    result = mix_files(
+        [MixSource(src_empty, 0.5), MixSource(src_ok, 0.5)], out, total=40, seed=42
+    )
+
+    assert result.sources[0].written == 0
+    assert result.sources[1].written == 20  # gets its own allocation only
+    assert result.total_written == 20
+
+
+def test_invalid_json_lines_skipped(tmp_path):
+    src = tmp_path / "src.jsonl"
+    src.write_text('{"x": 1}\nNOT JSON\n{"x": 2}\n')
+
+    out = tmp_path / "out.jsonl"
+    result = mix_files([MixSource(src, 1.0)], out, seed=42)
+
+    assert result.total_written == 2
+
+
+# ---------------------------------------------------------------------------
+# mix_files — error handling
+# ---------------------------------------------------------------------------
+
+
+def test_missing_source_raises(tmp_path):
+    out = tmp_path / "out.jsonl"
+    with pytest.raises(FileNotFoundError):
+        mix_files([MixSource(tmp_path / "ghost.jsonl", 1.0)], out, total=10, seed=42)
+
+
+def test_no_sources_raises(tmp_path):
+    with pytest.raises(ValueError, match="At least one source"):
+        mix_files([], tmp_path / "out.jsonl", total=10, seed=42)
+
+
+def test_zero_weight_raises(tmp_path):
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": 1}])
+    with pytest.raises(ValueError, match="positive"):
+        mix_files([MixSource(src, 0.0)], tmp_path / "out.jsonl", total=10, seed=42)
+
+
+# ---------------------------------------------------------------------------
+# write_mix_recipe
+# ---------------------------------------------------------------------------
+
+
+def test_recipe_sidecar_content(tmp_path):
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": i} for i in range(100)])
+    out = tmp_path / "out.jsonl"
+    result = mix_files([MixSource(src, 1.0)], out, total=50, seed=99)
+
+    sidecar = write_mix_recipe(result)
+
+    assert sidecar == out.with_suffix(".mix.json")
+    data = json.loads(sidecar.read_text())
+    assert data["seed"] == 99
+    assert data["total_written"] == 50
+    assert data["version"] == 1
+    assert len(data["sources"]) == 1
+    assert "created_at" in data
+
+
+# ---------------------------------------------------------------------------
+# load_mix_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_json_config(tmp_path):
+    cfg = {
+        "seed": 7,
+        "total": 500,
+        "output": str(tmp_path / "out.jsonl"),
+        "sources": [
+            {"path": str(tmp_path / "a.jsonl"), "weight": 0.7},
+            {"path": str(tmp_path / "b.jsonl"), "weight": 0.3},
+        ],
+    }
+    config_path = tmp_path / "mix.json"
+    config_path.write_text(json.dumps(cfg))
+
+    sources, options = load_mix_config(config_path)
+
+    assert len(sources) == 2
+    assert sources[0].weight == 0.7
+    assert options["seed"] == 7
+    assert options["total"] == 500
+
+
+def test_load_config_missing_path_raises(tmp_path):
+    cfg = {"sources": [{"weight": 0.5}]}
+    config_path = tmp_path / "bad.json"
+    config_path.write_text(json.dumps(cfg))
+    with pytest.raises(ValueError, match="path"):
+        load_mix_config(config_path)
+
+
+def test_load_config_empty_sources_raises(tmp_path):
+    cfg = {"sources": []}
+    config_path = tmp_path / "bad.json"
+    config_path.write_text(json.dumps(cfg))
+    with pytest.raises(ValueError, match="non-empty"):
+        load_mix_config(config_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_inline_mix(tmp_path):
+    from convmerge.cli import main
+
+    src_a = tmp_path / "a.jsonl"
+    src_b = tmp_path / "b.jsonl"
+    write_jsonl(src_a, [{"src": "a", "i": i} for i in range(100)])
+    write_jsonl(src_b, [{"src": "b", "i": i} for i in range(100)])
+    out = tmp_path / "mixed.jsonl"
+
+    main([
+        "mix",
+        "--input", f"{src_a}:0.6", f"{src_b}:0.4",
+        "--output", str(out),
+        "--total", "100",
+        "--seed", "42",
+    ])
+
+    lines = read_jsonl(out)
+    assert len(lines) == 100
+    assert out.with_suffix(".mix.json").is_file()
+
+
+def test_cli_config_file_mix(tmp_path):
+    from convmerge.cli import main
+
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": i} for i in range(200)])
+    out = tmp_path / "out.jsonl"
+
+    cfg = {
+        "seed": 1,
+        "total": 50,
+        "output": str(out),
+        "sources": [{"path": str(src), "weight": 1.0}],
+    }
+    config_path = tmp_path / "mix.json"
+    config_path.write_text(json.dumps(cfg))
+
+    main(["mix", str(config_path)])
+
+    assert len(read_jsonl(out)) == 50
+
+
+def test_cli_no_recipe_flag(tmp_path):
+    from convmerge.cli import main
+
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": i} for i in range(50)])
+    out = tmp_path / "out.jsonl"
+
+    main([
+        "mix",
+        "--input", f"{src}:1.0",
+        "--output", str(out),
+        "--no-recipe",
+    ])
+
+    assert out.is_file()
+    assert not out.with_suffix(".mix.json").exists()
+
+
+def test_cli_missing_output_exits(tmp_path):
+    from convmerge.cli import main
+
+    src = tmp_path / "src.jsonl"
+    write_jsonl(src, [{"x": 1}])
+
+    with pytest.raises(SystemExit) as exc:
+        main(["mix", "--input", f"{src}:1.0"])
+    assert exc.value.code != 0
+
+
+def test_cli_bad_spec_exits(tmp_path):
+    from convmerge.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["mix", "--input", "no-colon-here", "--output", str(tmp_path / "out.jsonl")])
+    assert exc.value.code != 0


### PR DESCRIPTION
## Summary

- Adds `convmerge mix` — a new pipeline step between `convert` and `dedupe`
- Samples from multiple JSONL sources at specified weights with a fixed seed for full reproducibility
- Writes a sidecar `.mix.json` recipe file recording exact parameters for audit/replay
- Zero changes to existing commands or modules

## Usage

```bash
# Inline
convmerge mix -i code.jsonl:0.4 math.jsonl:0.3 general.jsonl:0.3 \
  -o mixed.jsonl --total 100000 --seed 42

# Config file (YAML requires convmerge[preset])
convmerge mix mix.yaml
```

```yaml
# mix.yaml
seed: 42
total: 100000
output: ./train/mixed.jsonl
sources:
  - path: ./train/code.jsonl
    weight: 0.4
  - path: ./train/math.jsonl
    weight: 0.3
  - path: ./train/general.jsonl
    weight: 0.3
```

## Test plan

- [x] 24 tests covering allocation, reproducibility, clip, oversample, config loading, and CLI modes
- [x] All existing tests pass (111 total)
- [x] Rebased onto current main (includes #19)